### PR TITLE
add tests to the default permission code

### DIFF
--- a/_1327/documents/__init__.py
+++ b/_1327/documents/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = '_1327.documents.apps.DocumentConfig'

--- a/_1327/documents/apps.py
+++ b/_1327/documents/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+class DocumentConfig(AppConfig):
+	name = '_1327.documents'
+
+	def ready(self):
+		import _1327.documents.signals


### PR DESCRIPTION
entirely fixes #76 by adding tests and putting the signal intialisation code into the right spot as descibed in https://docs.djangoproject.com/en/1.7/topics/signals/