### PR TITLE
MenuItems should exclusively reference a Document or a Link

### DIFF
--- a/_1327/main/admin.py
+++ b/_1327/main/admin.py
@@ -20,6 +20,12 @@ class MenuItemAdminForm(forms.ModelForm):
 				raise ValidationError(_('This link is not valid.'), code='nonexistent')
 		return data
 
+	def clean(self):
+		if self.cleaned_data['link'] and self.cleaned_data['document']:
+			raise ValidationError(_('You are only allowed to define one of Document and Link'))
+
+		return self.cleaned_data
+
 
 class MenuItemAdmin(admin.ModelAdmin):
 	form = MenuItemAdminForm


### PR DESCRIPTION
MenuItemAdminForm now prevents setting link and document reference at the same time