### PR TITLE
Fix #96: Add word break for long lines in document diffs

### DIFF
--- a/_1327/static/less/1327.less
+++ b/_1327/static/less/1327.less
@@ -7,6 +7,12 @@
 }
 // End fix.
 
+// Fix jsdifflib line wrapping:
+table.diff {
+	word-break: break-all;
+}
+// End fix.
+
 html {
 	height: 100%;
 }


### PR DESCRIPTION
This fixes long lines making the table too large.

![line-wrapping](https://cloud.githubusercontent.com/assets/2820802/7124874/c13f7f1c-e22c-11e4-9495-757ff2547e0b.png)
