### PR TITLE
File uploading

### DIFF
--- a/_1327/documents/admin.py
+++ b/_1327/documents/admin.py
@@ -5,7 +5,7 @@ import reversion
 
 from _1327.information_pages.admin import InformationDocumentAdmin
 from _1327.information_pages.models import InformationDocument
-from .models import Document
+from .models import Document, Attachment
 
 
 class DocumentAdmin(GuardedModelAdmin, reversion.VersionAdmin, PolymorphicParentModelAdmin):
@@ -17,3 +17,9 @@ class DocumentAdmin(GuardedModelAdmin, reversion.VersionAdmin, PolymorphicParent
 	list_display = ('author', 'title', 'text')
 
 admin.site.register(Document, DocumentAdmin)
+
+
+class AttachmentAdmin(admin.ModelAdmin):
+	pass
+
+admin.site.register(Attachment, AttachmentAdmin)

--- a/_1327/documents/forms.py
+++ b/_1327/documents/forms.py
@@ -3,6 +3,8 @@ from django.contrib.auth.models import Group
 from django.utils.translation import ugettext_lazy as _
 from guardian.shortcuts import get_perms_for_model, assign_perm, remove_perm
 
+from .models import Attachment
+
 
 class StrippedCharField(forms.CharField):
 	"""
@@ -31,7 +33,6 @@ class PermissionForm(forms.Form):
 	view_permission = forms.BooleanField(required=False)
 	group_name = forms.CharField(required=False)
 
-
 	def __init__(self, *args, **kwargs):
 		super().__init__(*args, **kwargs)
 		self.fields["group_name"].widget = forms.HiddenInput()
@@ -55,3 +56,9 @@ class PermissionForm(forms.Form):
 					assign_perm(permission.codename, group, model)
 				else:
 					remove_perm(permission.codename, group, model)
+
+
+class AttachmentForm(forms.ModelForm):
+	class Meta:
+		model = Attachment
+		exclude = ('document',)

--- a/_1327/documents/migrations/0007_attachment.py
+++ b/_1327/documents/migrations/0007_attachment.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('documents', '0006_merge'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Attachment',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created', models.DateTimeField(auto_now=True)),
+                ('file', models.FileField(upload_to='documents/%y/%m/')),
+                ('document', models.ForeignKey(related_name='attachments', to='documents.Document')),
+                ('displayname', models.TextField(max_length=255, blank=True, default='')),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/_1327/documents/models.py
+++ b/_1327/documents/models.py
@@ -43,3 +43,11 @@ class TemporaryDocumentText(models.Model):
 	text = models.TextField()
 	document = models.ForeignKey(Document, related_name='document')
 	created = models.DateTimeField(auto_now=True)
+
+
+class Attachment(models.Model):
+
+	displayname = models.TextField(max_length=255, blank=True, default="")
+	document = models.ForeignKey(Document, related_name='attachments')
+	created = models.DateTimeField(auto_now=True)
+	file = models.FileField(upload_to="documents/%y/%m/")

--- a/_1327/documents/templates/attachments.html
+++ b/_1327/documents/templates/attachments.html
@@ -1,0 +1,101 @@
+{% load i18n %}
+{% load filename %}
+
+{% block information_page_content %}
+	<h2>{% trans "Add an attachment" %}</h2>
+
+	{% if form.errors %}
+		<div class="alert alert-danger alert-margin-bottom" role="alert">{% trans "Please provide the missing information" %}</div>
+	{% endif %}
+
+	<form class="form-horizontal" action="{{ edit_url }}" method="post" role="form" enctype="multipart/form-data">
+		{% csrf_token %}
+		<div class="form-group {% if 'displayname' in form.errors %}has-error{% endif %}">
+			<label for="inputFile" class="col-sm-2 control-label">{% trans "Displayname" %}</label>
+			<div class="col-sm-9">
+				<input type="text" class="form-control" name="displayname" value="{{ form.data.displayname }}" placeholder="{% trans "Optional displayname..." %}">
+			</div>
+		</div>
+		<div class="form-group {% if 'file' in form.errors %}has-error{% endif %}">
+			<label for="inputFile" class="col-sm-2 control-label">{% trans "Attachment" %}</label>
+			<div class="col-sm-9">
+				<input type="file" class="form-control" name="file" value="{{ form.data.file }}" placeholder="{% trans "Your Attachment..." %}">
+			</div>
+		</div>
+		<div class="form-group">
+			<div class="col-sm-offset-2 col-sm-4">
+				<button type="submit" class="btn btn-primary">
+					<i class="glyphicon glyphicon-floppy-disk"></i> {% trans 'Save' %}
+				</button>
+			</div>
+		</div>
+	</form>
+
+	<h2>{% trans "Already uploaded attachments" %}</h2>
+	<div class="col-sm-12">
+		<table class="table table-striped">
+			<thead>
+				<th>{% trans "Displayname" %}</th>
+				<th>{% trans "Filename" %}</th>
+				<th>{% trans "Created" %}</th>
+			</thead>
+			{% for attachment in attachments %}
+				<tr>
+					<td>
+						<input type="hidden" class="attachmentinput" name="file" value="{{ attachment.id }}">
+						<a href="{% url 'documents:download_attachment' %}?attachment_id={{ attachment.id }}">{{ attachment.displayname }}</a>
+					</td>
+					<td>{{ attachment.file.name|filename }}</td>
+					<td>{{ attachment.created }}</td>
+					<td>
+						<button type="button" data-displayname="{{ attachment.displayname }}" data-toggle="modal"
+						        data-target="#confirmAttachmentDeleteModal" class="delete-attachment btn btn-warning">
+							{% trans "Delete" %}
+						</button>
+					</td>
+				</tr>
+
+			{% endfor %}
+		</table>
+	</div>
+
+	<div class="modal fade" id="confirmAttachmentDeleteModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+		<div class="modal-dialog">
+			<div class="modal-content">
+				<div class="modal-header">
+					<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+						<span aria-hidden="true">&times;</span>
+					</button>
+					<div class="modal-title">{% trans "Please Confirm" %}</div>
+				</div>
+				<div class="modal-body">
+					{% blocktrans %}
+					Do you really want to delete the Attachment <span id="attachment-name"></span>?
+					{% endblocktrans %}
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="btn btn-primary" id="accept-delete">{% trans "Yes" %}</button>
+					<button type="button" class="btn btn-default" data-dismiss="modal">{% trans "No" %}</button>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<script>
+		$('#confirmAttachmentDeleteModal').on('show.bs.modal', function (event){
+			var button = $(event.relatedTarget);
+			var input = button.closest('tr').find('input.attachmentinput');
+			$('#attachment-name').html(button.data['displayname']);
+            var deleteButton = $('#accept-delete');
+            deleteButton.off('click');
+			deleteButton.on('click', function (event){
+				$.post("{% url "documents:delete_attachment" %}", {'id': input.attr('value')}, function (data, textStatus, jqXHR) {
+					location.reload()
+				});
+			});
+		});
+	</script>
+
+
+{% endblock %}
+

--- a/_1327/documents/templatetags/__init__.py
+++ b/_1327/documents/templatetags/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'Bartzi'

--- a/_1327/documents/templatetags/filename.py
+++ b/_1327/documents/templatetags/filename.py
@@ -1,0 +1,9 @@
+import os
+
+from django import template
+register = template.Library()
+
+@register.filter
+def filename(string):
+    delimiter = os.sep
+    return string.split(delimiter)[-1]

--- a/_1327/documents/urls.py
+++ b/_1327/documents/urls.py
@@ -5,4 +5,6 @@ admin.autodiscover()
 
 urlpatterns = patterns('_1327.documents.views',
 	url(r"revert/$", 'revert', name='revert'),
+	url(r"deleteattachment/$", 'delete_attachment', name='delete_attachment'),
+	url(r"download/$", 'download_attachment', name='download_attachment'),
 )

--- a/_1327/documents/views.py
+++ b/_1327/documents/views.py
@@ -1,14 +1,17 @@
+from django.contrib import messages
 from django.shortcuts import get_object_or_404, Http404
-from django.http import HttpResponse, HttpResponseServerError, HttpResponseBadRequest
+from django.http import HttpResponse, HttpResponseServerError, HttpResponseBadRequest, HttpResponseForbidden
 from django.db import transaction
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.contenttypes.models import ContentType
 
 import reversion
+import os
 from reversion.models import RevertError
+from sendfile import sendfile
+from _1327 import settings
 
-from _1327.documents.models import Document
-from _1327.user_management.models import UserProfile
+from _1327.documents.models import Document, Attachment
 from _1327.user_management.shortcuts import get_object_or_error
 
 
@@ -50,8 +53,39 @@ def revert(request):
 
 	reverted_document = document_class(author_id=fields.pop('author'), **fields)
 	with transaction.atomic(), reversion.create_revision():
-				reverted_document.save()
-				reversion.set_user(request.user)
-				reversion.set_comment(_('reverted to revision \"{revision_comment}\"'.format(revision_comment=revert_version.revision.comment)))
+		reverted_document.save()
+		reversion.set_user(request.user)
+		reversion.set_comment(
+			_('reverted to revision \"{revision_comment}\"'.format(revision_comment=revert_version.revision.comment)))
 
 	return HttpResponse()
+
+
+def delete_attachment(request):
+	if request.is_ajax() and request.method == "POST":
+		attachment = Attachment.objects.get(id=request.POST['id'])
+		# check whether user has permission to change the document the attachment belongs to
+		document = attachment.document
+		class_name = document.__class__.__name__.lower()
+		if not request.user.has_perm('change_{}'.format(class_name), document):
+			return HttpResponseForbidden()
+
+		attachment.file.delete()
+		attachment.delete()
+		messages.success(request, _("Successfully deleted Attachment!"))
+		return HttpResponse()
+	raise Http404()
+
+
+def download_attachment(request):
+	if not request.method == "GET":
+		return HttpResponseBadRequest()
+
+	attachment = get_object_or_404(Attachment, pk=request.GET['attachment_id'])
+	# check whether user is allowed to see that document and thus download the attachment
+	document = attachment.document
+	if not request.user.has_perm(document.VIEW_PERMISSION_NAME, document):
+		return HttpResponseForbidden()
+
+	filename = os.path.join(settings.MEDIA_ROOT, attachment.file.name)
+	return sendfile(request, filename, attachment=True, attachment_filename=attachment.displayname)

--- a/_1327/information_pages/templates/information_pages_attachments.html
+++ b/_1327/information_pages/templates/information_pages_attachments.html
@@ -1,0 +1,9 @@
+{% extends 'information_pages_base.html' %}
+
+{% block title %}
+	{{ document.title }}
+{% endblock %}
+
+{% block information_page_content %}
+	{% include 'attachments.html' %}
+{% endblock %}

--- a/_1327/information_pages/templates/information_pages_base.html
+++ b/_1327/information_pages/templates/information_pages_base.html
@@ -17,6 +17,7 @@
 			<div class="divider"></div>
 			<a class="btn btn-sm btn-sidebar {% if active_page == 'view' %}btn-warning{% else %}btn-default{% endif %}" href="{% url 'information_pages:view_information' document.url_title %}" role="tab">{% trans "View" %}</a>
 			<a class="btn btn-sm btn-sidebar {% if active_page == 'edit' %}btn-warning{% else %}btn-default{% endif %}" href="{% url 'information_pages:edit' document.url_title %}" role="tab">{% trans "Edit" %}</a>
+			<a class="btn btn-sm btn-sidebar {% if active_page == 'attachments' %}btn-warning{% else %}btn-default{% endif %}" href="{% url 'information_pages:attachments' document.url_title %}" role="tab">{% trans "Attachments" %}</a>
 			<a class="btn btn-sm btn-sidebar {% if active_page == 'permissions' %}btn-warning{% else %}btn-default{% endif %}" href="{% url 'information_pages:permissions' document.url_title %}" role="tab">{% trans "Permissions" %}</a>
 			<a class="btn btn-sm btn-sidebar {% if active_page == 'versions' %}btn-warning{% else %}btn-default{% endif %}" href="{% url 'information_pages:versions' document.url_title %}" role="tab">{% trans "Versions" %}</a>
 		{% endif %}
@@ -26,6 +27,17 @@
 {% block content %}
 	{% block information_page_content %}
 		<div class="markdown-text">{{ document.text }}</div>
+		{% if attachments %}
+			<div class="divider"></div>
+			<h2>{% trans "Attachments" %}</h2>
+			{% for attachment in attachments %}
+				<div class="row">
+					<div class="col-sm-4">
+						<a href="{% url 'documents:download_attachment' %}?attachment_id={{ attachment.id }}">{{ attachment.displayname }}</a>
+					</div>
+				</div>
+			{% endfor %}
+		{% endif %}
 	{% endblock %}
 {% endblock %}
 

--- a/_1327/information_pages/urls.py
+++ b/_1327/information_pages/urls.py
@@ -8,5 +8,6 @@ urlpatterns = patterns('_1327.information_pages.views',
 	url(r"autosave/(?P<title>[\w-]+)/$", 'autosave', name='autosave'),
 	url(r"versions/(?P<title>[\w-]+)/$", 'versions', name="versions"),
 	url(r"permissions/(?P<title>[\w-]+)/$", 'permissions', name="permissions"),
+	url(r"attachments/(?P<title>[\w-]+)/$", 'attachments', name="attachments"),
 	url(r"(?P<title>[\w-]+)/$", 'view_information', name='view_information'),
 )

--- a/_1327/settings.py
+++ b/_1327/settings.py
@@ -114,6 +114,19 @@ STATIC_URL = '/static/'
 # Example: "/opt/_1327/_1327/static/"
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 
+# Absolute path to the directory user uploaded files (like pdf and png) should be put in.
+# Example: "/opt/_1327/_1327/media/"
+MEDIA_ROOT = os.path.join(BASE_DIR, "media")
+
+# the Backend used for downloading attachments may be one of the following:
+# `sendfile.backends.development` - for use with django development server only. DO NOT USE IN PRODUCTION
+# `sendfile.backends.simple` - "simple" backend that uses Django file objects to attempt to stream files from disk (note middleware may cause files to be loaded fully into memory)
+# `sendfile.backends.xsendfile` - sets X-Sendfile header (as used by mod_xsendfile/apache and lighthttpd)
+# `sendfile.backends.mod_wsgi` - sets Location with 200 code to trigger internal redirect (daemon mode mod_wsgi only - see below)
+# `sendfile.backends.nginx` - sets X-Accel-Redirect header to trigger internal redirect to file
+# see https://github.com/johnsensible/django-sendfile for further information
+SENDFILE_BACKEND = 'sendfile.backends.development'
+
 # Additional locations of static files
 STATICFILES_DIRS = (
 	os.path.join(BASE_DIR, "static"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ django-webtest >= 1.7.7
 django-reversion >= 1.8.4
 django-guardian >= 1.2.5
 django-polymorphic >= 0.6.1
+django-sendfile >= 0.3.6


### PR DESCRIPTION
Fixes #36 
It is now possible to add attachments to documents, attachments can be uploaded and will be saved in a media folder, attachments can be deleted and downloaded. This PR also includes tests for that functionality.

**Please Note**
The download feature needs the server to use the mod_sendfile extension as the file download first needs to be checked for sufficient permissions and is then handled by the webserver (this is a nice way i think)