### PR TITLE
Added document TOC to information page sidebar

### DIFF
--- a/_1327/information_pages/templates/information_pages_base.html
+++ b/_1327/information_pages/templates/information_pages_base.html
@@ -10,6 +10,7 @@
 {% endblock %}
 
 {% block sidebar %}
+	{{ toc|safe }}
 	<dl class="meta-information">
 		<dt>{% trans "Author" %}</dt>
 		<dd>{{ document.author }}</dd>
@@ -31,7 +32,7 @@
 
 {% block content %}
 	{% block information_page_content %}
-		<div class="markdown-text">{{ document.text }}</div>
+		<div>{{ text|safe }}</div>
 		{% if attachments %}
 			<div class="divider"></div>
 			<h2>{% trans "Attachments" %}</h2>
@@ -43,17 +44,5 @@
 				</div>
 			{% endfor %}
 		{% endif %}
-	{% endblock %}
-{% endblock %}
-
-
-{% block scripts %}
-	{{ block.super }}
-	{% block information_pages_scripts %}
-		<script type="text/javascript" src="{% static 'js/markdown.js' %}"></script>
-		<script>
-			var markdownContainer = $('.markdown-text');
-			markdownContainer.html(markdown.toHTML(markdownContainer.text()));
-		</script>
 	{% endblock %}
 {% endblock %}

--- a/_1327/information_pages/views.py
+++ b/_1327/information_pages/views.py
@@ -8,6 +8,8 @@ from django.forms.formsets import formset_factory
 from guardian.shortcuts import get_perms
 from guardian.models import Group
 from datetime import datetime
+import markdown
+from markdown.extensions.toc import TocExtension
 
 from _1327.documents.utils import handle_edit, prepare_versions, handle_autosave, handle_attachment
 from _1327.documents.models import Document
@@ -67,8 +69,13 @@ def versions(request, title):
 def view_information(request, title):
 	document = get_object_or_error(InformationDocument, request.user, [InformationDocument.get_view_permission()], url_title=title)
 
+	md = markdown.Markdown(safe_mode='escape', extensions=[TocExtension(baselevel=2)])
+	text = md.convert(document.text)
+
 	return render(request, 'information_pages_base.html', {
 		'document': document,
+		'text': text,
+		'toc': md.toc,
 		'attachments': document.attachments.all(),
 		'active_page': 'view',
 	})

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ django-reversion >= 1.8.4
 django-guardian >= 1.2.5
 django-polymorphic >= 0.6.1
 django-sendfile >= 0.3.6
+
+Markdown >= 2.6.0


### PR DESCRIPTION
Page markdown is now rendered in Python instead of JavaScript.

Closes #129.

@janno42: You'll have to make it look nice. ;)