### PR TITLE
Fixed static precompiler

### DIFF
--- a/_1327/documents/templates/diffviewer.html
+++ b/_1327/documents/templates/diffviewer.html
@@ -5,7 +5,7 @@
 {# if you want to reuse this template you need to provide the following data: #}
 {# a tuple looking as follows: (number_of_version, version of the document, text_to_diff) #}
 
-<link rel="stylesheet" href="{% get_static_prefix %}{% compile 'less/diffview.less' %}" />
+<link rel="stylesheet" href="{% static 'less/diffview.less'|compile %}" />
 
 <h2>{% trans "Diff page versions" %}</h2>
 

--- a/_1327/documents/templates/diffviewer_scripts.html
+++ b/_1327/documents/templates/diffviewer_scripts.html
@@ -1,4 +1,4 @@
-{% load coffeescript %}
+{% load compile_static %}
 {% load i18n %}
 {% load static %}
 
@@ -23,7 +23,7 @@
 <script type="text/javascript" src="{% static 'js/difflib.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/diffview.js' %}"></script>
 <script>
-	{% inlinecoffeescript %}
+	{% inlinecompile "coffeescript" %}
 		versions = [];
 		{% for id, version, text in versions %}
 		versions.push([{{ version.pk }}, "{{ text }}"])
@@ -77,5 +77,5 @@
 				viewType: 0
 
 		createDiff()
-	{% endinlinecoffeescript %}
+	{% endinlinecompile %}
 </script>

--- a/_1327/information_pages/templates/information_pages_base.html
+++ b/_1327/information_pages/templates/information_pages_base.html
@@ -1,6 +1,4 @@
 {% extends 'base_with_sidebar.html' %}
-{% load static %}
-{% load compile_static %}
 {% load i18n %}
 {% load bootstrap3 %}
 {% load guardian_tags %}

--- a/_1327/minutes/templates/minutes_base.html
+++ b/_1327/minutes/templates/minutes_base.html
@@ -1,6 +1,4 @@
 {% extends 'base_with_sidebar.html' %}
-{% load static %}
-{% load compile_static %}
 {% load i18n %}
 {% load bootstrap3 %}
 {% load guardian_tags %}

--- a/_1327/settings.py
+++ b/_1327/settings.py
@@ -173,6 +173,10 @@ TEMPLATE_DIRS = (
 	os.path.join(BASE_DIR, "templates"),
 )
 
+STATIC_PRECOMPILER_COMPILERS = (
+	'static_precompiler.compilers.CoffeeScript',
+	'static_precompiler.compilers.LESS',
+)
 
 # Create a localsettings.py to override settings per machine or user, e.g. for
 # development or different settings in deployments using multiple servers.

--- a/_1327/templates/master.html
+++ b/_1327/templates/master.html
@@ -6,8 +6,8 @@
 <head>
 	{% block header %}
 		<title>myHPI – {% block title %}{% endblock %}</title>
-		<link rel="stylesheet" href="{% get_static_prefix %}{% compile 'less/bootstrap.less' %}" />
-		<link rel="stylesheet" href="{% get_static_prefix %}{% compile 'less/1327.less' %}" />
+		<link rel="stylesheet" href="{% static 'less/bootstrap.less'|compile %}" />
+		<link rel="stylesheet" href="{% static 'less/1327.less'|compile %}" />
 		<link rel="shortcut icon" type="image/x-icon" href="{{STATIC_URL}}/images/favicon.ico"/>
 		<link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.css">
 		{% block css %}{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 Django >=1.8, <1.9
-django-static-precompiler >=0.7
-# Required by django-static-precompiler:
-six
+django-static-precompiler >=1.0, <1.1
 
 django-bootstrap3 >= 5.4.0
 django-admin-bootstrapped >= 2.5


### PR DESCRIPTION
We didn't pin the version of django-static-precompiler. A few of the template tags and config changed, this PR fixes the issues.