### PR TITLE
Fixed attachments for minutes

### DIFF
--- a/_1327/documents/tests.py
+++ b/_1327/documents/tests.py
@@ -515,7 +515,7 @@ class TestAttachments(WebTest):
 			user=self.user,
 			xhr=True,
 		)
-		self.assertEqual(response.status_code, 200, "it should be possible to change the downloadable state")
+		self.assertEqual(response.status_code, 200, "it should be possible to change the direct download state")
 		attachment = Attachment.objects.get(pk=self.attachment.id)
 		self.assertFalse(attachment.no_direct_download)
 

--- a/_1327/minutes/views.py
+++ b/_1327/minutes/views.py
@@ -104,7 +104,7 @@ def view(request, title):
 		'document': document,
 		'text': text,
 		'toc': md.toc,
-		'attachments': document.attachments.filter(downloadable=True).order_by('index'),
+		'attachments': document.attachments.filter(no_direct_download=False).order_by('index'),
 		'active_page': 'view',
 	})
 


### PR DESCRIPTION
It's impossible to view minutes after @Bartzi forgot to modify references to `downloadable` after renaming the field in #199. This PR fixes the issue.