### PR TITLE
Fixed Django 1.9 deprecation warnings

### DIFF
--- a/_1327/minutes/__init__.py
+++ b/_1327/minutes/__init__.py
@@ -1,1 +1,0 @@
-from .forms import MinutesDocumentForm  # noqa


### PR DESCRIPTION
I removed the import that you added in #214, @Nef10. I can't remember what the problem was, but I couldn't find anything that breaks after removing it now.