### PR TITLE
Permissions for Polls

### DIFF
--- a/_1327/documents/forms.py
+++ b/_1327/documents/forms.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.contrib.auth.models import Group, Permission
 from django.core.exceptions import ValidationError
 from django.forms import BooleanField
+from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 from guardian.shortcuts import assign_perm, get_perms, remove_perm
@@ -61,10 +62,11 @@ class PermissionBaseForm(forms.BaseForm):
 	def header(cls):
 		output = [
 			'<tr>',
-			'<th class="col-md-6"> {} </th>'.format(_("Role")),
+			'<th class="col-md-6">{}</th>'.format(_("Role")),
 		]
+		# add one table head entry for every permission in this form
 		for permission in sorted([name for name, field in filter(lambda x: type(x[1]) == BooleanField, cls.base_fields.items())]):
-			item = "<th class=\"col-md-2 text-center\"> {} </th>".format(_(permission.rsplit('_')[0]))
+			item = "<th class=\"col-md-2 text-center\">{}</th>".format(force_text(_(permission.rsplit('_')[0])))
 			output.append(item)
 		output.append('</tr>')
 		return mark_safe('\n'.join(output))
@@ -73,14 +75,14 @@ class PermissionBaseForm(forms.BaseForm):
 		"Returns this form rendered as HTML <tr>"
 		output = [
 			"<tr>",
-			"<td>{}</td>".format(self['group_name'].value())
+			"<td>{}</td>".format(force_text(self['group_name'].value()))
 		]
 
 		for name in sorted(self.fields.keys()):
 			if name == "group_name":
 				continue
-			output.append('<td class="text-center"> {} </td>'.format(self[name]))
-		output.append(str(self['group_name']))
+			output.append('<td class="text-center">{}</td>'.format(force_text(self[name])))
+		output.append(force_text(str(self['group_name'])))
 		output.append("</tr>")
 
 		return mark_safe('\n'.join(output))

--- a/_1327/documents/forms.py
+++ b/_1327/documents/forms.py
@@ -1,9 +1,11 @@
 from django import forms
 from django.conf import settings
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import Group, Permission
 from django.core.exceptions import ValidationError
+from django.forms import BooleanField
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
-from guardian.shortcuts import assign_perm, get_perms_for_model, remove_perm
+from guardian.shortcuts import assign_perm, get_perms, remove_perm
 
 from .models import Attachment, Document
 
@@ -40,39 +42,70 @@ class DocumentForm(forms.ModelForm):
 Document.Form = DocumentForm
 
 
-class PermissionForm(forms.Form):
+class PermissionBaseForm(forms.BaseForm):
 	"""
 		Form that can be used to change permissions of a document object
 	"""
 
-	change_permission = forms.BooleanField(required=False)
-	delete_permission = forms.BooleanField(required=False)
-	view_permission = forms.BooleanField(required=False)
-	group_name = forms.CharField(required=False)
-
-	def __init__(self, *args, **kwargs):
-		super().__init__(*args, **kwargs)
-		self.fields["group_name"].widget = forms.HiddenInput()
-
 	def save(self, model):
 		group = Group.objects.get(name=self.cleaned_data["group_name"])
-		possible_permissions = get_perms_for_model(model)
-		for permission in possible_permissions:
-			if "change" in str(permission):
-				if self.cleaned_data["change_permission"]:
-					assign_perm(permission.codename, group, model)
-				else:
-					remove_perm(permission.codename, group, model)
-			elif "delete" in str(permission):
-				if self.cleaned_data["delete_permission"]:
-					assign_perm(permission.codename, group, model)
-				else:
-					remove_perm(permission.codename, group, model)
-			elif "view" in str(permission):
-				if self.cleaned_data["view_permission"]:
-					assign_perm(permission.codename, group, model)
-				else:
-					remove_perm(permission.codename, group, model)
+		for field_name, value in self.cleaned_data.items():
+			if field_name == 'group_name':
+				continue
+			if value:
+				assign_perm(field_name, group, model)
+			else:
+				remove_perm(field_name, group, model)
+
+	@classmethod
+	def header(cls):
+		output = [
+			'<tr>',
+			'<th class="col-md-6"> {} </th>'.format(_("Role")),
+		]
+		for permission in sorted([name for name, field in filter(lambda x: type(x[1]) == BooleanField, cls.base_fields.items())]):
+			item = "<th class=\"col-md-2 text-center\"> {} </th>".format(_(permission.rsplit('_')[0]))
+			output.append(item)
+		output.append('</tr>')
+		return mark_safe('\n'.join(output))
+
+	def as_table(self):
+		"Returns this form rendered as HTML <tr>"
+		output = [
+			"<tr>",
+			"<td>{}</td>".format(self['group_name'].value())
+		]
+
+		for name in sorted(self.fields.keys()):
+			if name == "group_name":
+				continue
+			output.append('<td class="text-center"> {} </td>'.format(self[name]))
+		output.append(str(self['group_name']))
+		output.append("</tr>")
+
+		return mark_safe('\n'.join(output))
+
+	@classmethod
+	def prepare_initial_data(cls, groups, content_type, obj=None):
+		initial_data = []
+		for group in groups:
+			if obj is not None:
+				group_permissions = get_perms(group, obj)
+			else:
+				group_permissions = [permission.codename for permission in group.permissions.filter(content_type=content_type)]
+
+			data = {permission: True for permission in group_permissions}
+			data["group_name"] = group.name
+			initial_data.append(data)
+		return initial_data
+
+
+def get_permission_form(content_type):
+	fields = {
+		permission.codename: forms.BooleanField(required=False) for permission in Permission.objects.filter(content_type=content_type)
+	}
+	fields['group_name'] = forms.CharField(required=False, widget=forms.HiddenInput())
+	return type('PermissionForm', (PermissionBaseForm,), {'base_fields': fields})
 
 
 class AttachmentForm(forms.ModelForm):

--- a/_1327/documents/templates/permission_editor.html
+++ b/_1327/documents/templates/permission_editor.html
@@ -9,22 +9,11 @@
 	<div class="form-group">
 		<table class="table table-striped vertically-aligned table-narrow" >
 			<thead>
-				<tr>
-					<th class="col-md-6">{% trans "Role" %}</th>
-					<th class="col-md-2 text-center">{% trans "View" %}</th>
-					<th class="col-md-2 text-center">{% trans "Edit" %}</th>
-					<th class="col-md-2 text-center">{% trans "Delete" %}</th>
-				</tr>
+				{{ formset_header }}
 			</thead>
 			<tbody>
 			{% for form in formset %}
-				<tr>
-					{{ form.group_name }}
-					<td>{{ form.group_name.value }}</td>
-					<td class="text-center">{{ form.view_permission }}</td>
-					<td class="text-center">{{ form.change_permission }}</td>
-					<td class="text-center">{{ form.delete_permission }}</td>
-				</tr>
+				{{ form.as_table }}
 			{% endfor %}
 			</tbody>
 		</table>

--- a/_1327/minutes/views.py
+++ b/_1327/minutes/views.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
 from django.forms import inlineformset_factory
 from django.forms.formsets import formset_factory
@@ -10,12 +11,11 @@ from django.shortcuts import render
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
 from guardian.models import Group
-from guardian.shortcuts import get_perms
 import markdown
 from markdown.extensions.toc import TocExtension
 
 from _1327 import settings
-from _1327.documents.forms import PermissionForm
+from _1327.documents.forms import get_permission_form
 from _1327.documents.models import Document
 from _1327.documents.utils import (
 	delete_old_empty_pages,
@@ -126,21 +126,12 @@ def view(request, title):
 def permissions(request, title):
 	document = get_object_or_error(MinutesDocument, request.user, ['minutes.change_minutesdocument'], url_title=title)
 
-	permissionFS = formset_factory(form=PermissionForm, extra=0)
-	groups = Group.objects.all()
+	content_type = ContentType.objects.get_for_model(MinutesDocument)
+	PermissionForm = get_permission_form(content_type)
+	PermissionFormset = formset_factory(get_permission_form(content_type), extra=0)
 
-	initial_data = []
-	for group in groups:
-		group_permissions = get_perms(group, document)
-		data = {
-			"change_permission": "change_minutesdocument" in group_permissions,
-			"delete_permission": "delete_minutesdocument" in group_permissions,
-			"view_permission": MinutesDocument.VIEW_PERMISSION_NAME in group_permissions,
-			"group_name": group.name,
-		}
-		initial_data.append(data)
-
-	formset = permissionFS(request.POST or None, initial=initial_data)
+	initial_data = PermissionForm.prepare_initial_data(Group.objects.all(), content_type, document)
+	formset = PermissionFormset(request.POST or None, initial=initial_data)
 	if request.POST and formset.is_valid():
 		for form in formset:
 			form.save(document)
@@ -150,6 +141,7 @@ def permissions(request, title):
 
 	return render(request, 'minutes_permissions.html', {
 		'document': document,
+		'formset_header': PermissionForm.header(),
 		'formset': formset,
 		'active_page': 'permissions',
 		'permission_warning': permission_warning(request.user, document),

--- a/_1327/polls/migrations/0006_auto_20160222_1826.py
+++ b/_1327/polls/migrations/0006_auto_20160222_1826.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('polls', '0005_auto_20160216_2149'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='poll',
+            options={'permissions': (('view_poll', 'User/Group is allowed to view that poll'), ('vote_poll', 'User/Group is allowed to participate (vote) in that poll'))},
+        ),
+    ]

--- a/_1327/polls/models.py
+++ b/_1327/polls/models.py
@@ -5,6 +5,7 @@ from _1327.user_management.models import UserProfile
 
 
 POLL_VIEW_PERMISSION_NAME = 'view_poll'
+POLL_VOTE_PERMISSION_NAME = 'vote_poll'
 
 
 class Poll(models.Model):
@@ -20,6 +21,7 @@ class Poll(models.Model):
 	class Meta:
 		permissions = (
 			(POLL_VIEW_PERMISSION_NAME, 'User/Group is allowed to view that poll'),
+			(POLL_VOTE_PERMISSION_NAME, 'User/Group is allowed to participate (vote) in that poll'),
 		)
 
 

--- a/_1327/polls/templates/polls_create_poll.html
+++ b/_1327/polls/templates/polls_create_poll.html
@@ -15,7 +15,7 @@
 
 		<h3>{% trans "Choices for Poll" %}</h3>
 		<div class="divider"></div>
-		{{ formset.management_form }}
+		{{ choice_formset.management_form }}
 		<table id="choice-formset" class="table table-striped">
 			<thead>
 				<tr>
@@ -26,7 +26,7 @@
 				</tr>
 			</thead>
 			<tbody>
-				{% for form_element in formset %}
+				{% for form_element in choice_formset %}
 					<tr class="sortable">
 						{% for field in form_element.hidden_fields %}
 							{{ field }}
@@ -37,6 +37,19 @@
 						<td>{% if form_element.instance.pk %}{{ form_element.DELETE }}{% endif %}</td>
 					</tr>
 				{% endfor %}
+			</tbody>
+		</table>
+		<h3>{% trans "Permissions" %}</h3>
+		<div class="divider"></div>
+		{{ permission_formset.management_form }}
+		<table class="table table-striped vertically-aligned table-narrow" >
+			<thead>
+				{{ permission_header }}
+			</thead>
+			<tbody>
+			{% for form_element in permission_formset %}
+				{{ form_element.as_table }}
+			{% endfor %}
 			</tbody>
 		</table>
 		{% buttons %}

--- a/_1327/polls/tests.py
+++ b/_1327/polls/tests.py
@@ -258,7 +258,7 @@ class PollVoteTests(WebTest):
 
 		user = mommy.make(UserProfile)
 		assign_perm(Poll.VIEW_PERMISSION_NAME, user, self.poll)
-		assign_perm('change_poll', user, self.poll)
+		assign_perm('vote_poll', user, self.poll)
 		user.save()
 		response = self.app.get(reverse('polls:vote', args=[self.poll.id]), user=user)
 		self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
This PR enables us to provide permissions for polls, thereby refactoring the Permission form to be more general and easy to adapt to new situations.

The code has two pitfalls:

1. I was not able to come up with a nicer rendering of permission names for each group. Does s.b. have a better idea?
2. I had to replace the `as_table ` method of the form. This is because I did not see another way of rendering the form in a generic way and the standard as_table method does not render the html the way we want. If somebody has any suggestions...

Please also make sure to review whether I checked that all permissions are checked at the right place at the right time.

I will add tests later on. That's why this PR is WIP
