### PR TITLE
restore autosaves for each document type

### DIFF
--- a/_1327/documents/tests.py
+++ b/_1327/documents/tests.py
@@ -187,6 +187,26 @@ class TestAutosave(WebTest):
 		form = response.forms['document-form']
 		self.assertEqual(form.get('text').value, 'AUTO')
 
+	def test_autosave_with_different_document_types(self):
+		# create document
+		response = self.app.get(reverse('documents:create', args=['informationdocument']), user=self.user)
+		self.assertEqual(response.status_code, 200)
+		form = response.forms['document-form']
+		url_title = slugify(form.get('title').value)
+
+		# autosave AUTO
+		response = self.app.post(reverse('documents:autosave', args=[url_title]), {'text': 'AUTO', 'title': form.get('title').value, 'comment': ''}, xhr=True)
+		self.assertEqual(response.status_code, 200)
+
+		# there should be no restore link on creation page for different document type
+		response = self.app.get(reverse('documents:create', args=['poll']), user=self.user)
+		self.assertNotIn((reverse('documents:edit', args=[url_title]) + '?restore'), str(response.body))
+
+		# on the new page site should be a banner with a restore link
+		response = self.app.get(reverse('documents:create', args=['informationdocument']), user=self.user)
+		self.assertEqual(response.status_code, 200)
+		self.assertIn((reverse('documents:edit', args=[url_title]) + '?restore'), str(response.body))
+
 
 class TestSignals(TestCase):
 

--- a/_1327/documents/utils.py
+++ b/_1327/documents/utils.py
@@ -14,11 +14,14 @@ from _1327.documents.models import Document, TemporaryDocumentText
 from _1327.minutes.models import MinutesDocument
 
 
-def get_new_autosaved_pages_for_user(user):
+def get_new_autosaved_pages_for_user(user, content_type):
 	autosaved_pages = []
 	all_temp_documents = TemporaryDocumentText.objects.all()
 	for temp_document in all_temp_documents:
 		document = temp_document.document
+		# if contenttype of autosave does not match contenttype of current document we will not show this autosave
+		if ContentType.objects.get_for_model(document) != content_type:
+			continue
 		if len(revisions.get_for_object(document)) == 0 and temp_document.author == user:
 			autosaved_pages.append(document)
 	return autosaved_pages

--- a/_1327/documents/views.py
+++ b/_1327/documents/views.py
@@ -50,7 +50,7 @@ def create(request, document_type):
 		if hasattr(model_class, 'moderator'):
 			kwargs['moderator'] = request.user
 		model_class.objects.get_or_create(**kwargs)
-		new_autosaved_pages = get_new_autosaved_pages_for_user(request.user)
+		new_autosaved_pages = get_new_autosaved_pages_for_user(request.user, content_type)
 		initial = {
 			'comment': _("Created document"),
 		}


### PR DESCRIPTION
fixes #336 

autosave restore suggestion is now only for the corresponding document type