### PR TITLE
 Show TOC only when it has content

### DIFF
--- a/_1327/documents/templates/documents_base.html
+++ b/_1327/documents/templates/documents_base.html
@@ -36,8 +36,10 @@
 			<div class="divider"></div>
 		{% endif %}
 	{% endblock %}
-	<p class="toc-heading">{% trans "Table of Contents" %}</p>
-	{{ toc|safe }}
+	{% if "<li>" in toc %}
+		<p class="toc-heading">{% trans "Table of Contents" %}</p>
+		{{ toc|safe }}
+	{% endif %}
 	{% if attachments %}
 		<div class="toc hidden-print">
 			<ul><li><a href="#attachments" title="{% trans "Attachments" %}">{% trans "Attachments" %}</a></li></ul>

--- a/_1327/polls/templatetags/poll_tags.py
+++ b/_1327/polls/templatetags/poll_tags.py
@@ -1,4 +1,5 @@
 import datetime
+
 from django import template
 
 register = template.Library()


### PR DESCRIPTION
fix #177
Don't show TOC on documents without headings