### PR TITLE
#439 Improve SQL queries for minutes list

### DIFF
--- a/_1327/minutes/views.py
+++ b/_1327/minutes/views.py
@@ -2,7 +2,7 @@ from django.contrib.auth.models import Group
 from django.core.exceptions import ObjectDoesNotExist, SuspiciousOperation
 from django.shortcuts import render
 
-from guardian.shortcuts import get_objects_for_group
+from guardian.core import ObjectPermissionChecker
 
 from _1327.minutes.models import MinutesDocument
 
@@ -14,11 +14,23 @@ def list(request, groupid):
 	except ObjectDoesNotExist:
 		raise SuspiciousOperation
 	result = {}
-	# we show all documents for which the requested group has edit permissions
-	# e.g. if you request FSR minutes, all minutes for which the FSR group has edit rights will be shown
-	minutes = get_objects_for_group(group, "minutes.change_minutesdocument", MinutesDocument).order_by('-date')
+
+	minutes = MinutesDocument.objects.all().prefetch_related('labels').order_by('-date')
+	# Prefetch group permissions
+	group_checker = ObjectPermissionChecker(group)
+	group_checker.prefetch_perms(minutes)
+
+	# Prefetch user permissions
+	user_checker = ObjectPermissionChecker(request.user)
+	user_checker.prefetch_perms(minutes)
+
 	for m in minutes:
-		if not request.user.has_perm(MinutesDocument.get_view_permission(), m):
+		# we show all documents for which the requested group has edit permissions
+		# e.g. if you request FSR minutes, all minutes for which the FSR group has edit rights will be shown
+		if not group_checker.has_perm("minutes.change_minutesdocument", m):
+			continue
+		# we only show documents for which the user has view permissions
+		if not user_checker.has_perm(MinutesDocument.get_view_permission(), m):
 			continue
 		if m.date.year not in result:
 			result[m.date.year] = []


### PR DESCRIPTION
This improves the number of SQL queries for the minutes list by prefetching the permissions and document labels.