### PR TITLE
Document urls

### DIFF
--- a/_1327/documents/models.py
+++ b/_1327/documents/models.py
@@ -39,7 +39,7 @@ class Document(PolymorphicModel):
 		def url(self, id):
 			document = Document.objects.get(id=id)
 			if document:
-				return reverse('documents:view', args=[document.url_title])
+				return reverse('view', args=[document.url_title])
 			return ''
 
 	def __str__(self):
@@ -52,19 +52,19 @@ class Document(PolymorphicModel):
 		raise NotImplementedError()
 
 	def get_view_url_name(self):
-		return 'documents:view'
+		return 'view'
 
 	def get_edit_url_name(self):
-		return 'documents:edit'
+		return 'edit'
 
 	def get_attachments_url_name(self):
-		return 'documents:attachments'
+		return 'attachments'
 
 	def get_permissions_url_name(self):
-		return 'documents:permissions'
+		return 'permissions'
 
 	def get_versions_url_name(self):
-		return 'documents:versions'
+		return 'versions'
 
 	@classmethod
 	def get_view_permission(klass):

--- a/_1327/documents/models.py
+++ b/_1327/documents/models.py
@@ -51,6 +51,21 @@ class Document(PolymorphicModel):
 	def get_edit_url(self):
 		raise NotImplementedError()
 
+	def get_view_url_name(self):
+		return 'documents:view'
+
+	def get_edit_url_name(self):
+		return 'documents:edit'
+
+	def get_attachments_url_name(self):
+		return 'documents:attachments'
+
+	def get_permissions_url_name(self):
+		return 'documents:permissions'
+
+	def get_versions_url_name(self):
+		return 'documents:versions'
+
 	@classmethod
 	def get_view_permission(klass):
 		content_type = ContentType.objects.get_for_model(klass)

--- a/_1327/documents/templates/documents_base.html
+++ b/_1327/documents/templates/documents_base.html
@@ -14,24 +14,24 @@
 		{% get_obj_perms request.user for document as "document_perms" %}
 		{% if "change" in document_perms %}
 			<div role="tablist" class="hidden-print">
-				<a class="btn btn-sm btn-sidebar {% if active_page == 'view' %}btn-warning{% else %}btn-default{% endif %}" href="{% url 'documents:view' document.url_title %}" role="tab">{% trans "View" %}</a>
-				<a class="btn btn-sm btn-sidebar {% if active_page == 'edit' %}btn-warning{% else %}btn-default{% endif %}" href="{% url 'documents:edit' document.url_title %}" role="tab">{% trans "Edit" %}</a>
-				<a class="btn btn-sm btn-sidebar {% if active_page == 'attachments' %}btn-warning{% else %}btn-default{% endif %}" href="{% url 'documents:attachments' document.url_title %}" role="tab">{% trans "Attachments" %}</a>
-				{% if document.show_permissions_editor %}<a class="btn btn-sm btn-sidebar {% if active_page == 'permissions' %}btn-warning{% else %}btn-default{% endif %}" href="{% url 'documents:permissions' document.url_title %}" role="tab" {% if permission_warning %}data-toggle="tooltip" data-placement="left" data-container="body" title="{% trans "Anonymous users are not allowed to see this site!" %}" {% endif %}>{% if permission_warning %}<span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span> {% endif %}{% trans "Permissions" %}</a>{% endif %}
+				<a class="btn btn-sm btn-sidebar {% if active_page == 'view' %}btn-warning{% else %}btn-default{% endif %}" href="{% url document.get_view_url_name document.url_title %}" role="tab">{% trans "View" %}</a>
+				<a class="btn btn-sm btn-sidebar {% if active_page == 'edit' %}btn-warning{% else %}btn-default{% endif %}" href="{% url document.get_edit_url_name document.url_title %}" role="tab">{% trans "Edit" %}</a>
+				<a class="btn btn-sm btn-sidebar {% if active_page == 'attachments' %}btn-warning{% else %}btn-default{% endif %}" href="{% url document.get_attachments_url_name document.url_title %}" role="tab">{% trans "Attachments" %}</a>
+				{% if document.show_permissions_editor %}<a class="btn btn-sm btn-sidebar {% if active_page == 'permissions' %}btn-warning{% else %}btn-default{% endif %}" href="{% url document.get_permissions_url_name document.url_title %}" role="tab" {% if permission_warning %}data-toggle="tooltip" data-placement="left" data-container="body" title="{% trans "Anonymous users are not allowed to see this site!" %}" {% endif %}>{% if permission_warning %}<span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span> {% endif %}{% trans "Permissions" %}</a>{% endif %}
 				{% if document.show_publish_button %}
 					<div class="btn-group btn-sidebar">
-					  <a class="btn btn-sm btn-default col-xs-9" href="{% url 'documents:publish' document.url_title 1 %}" role="tab">{% trans "Publish" %}</a>
+					  <a class="btn btn-sm btn-default col-xs-9" href="{% url document.get_publish_url_name document.url_title 1 %}" role="tab">{% trans "Publish" %}</a>
 					  <button type="button" class="btn btn-sm btn-default col-xs-3 dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 						<span class="caret"></span>
 						<span class="sr-only">Toggle Dropdown</span>
 					  </button>
 					  <ul class="dropdown-menu dropdown-menu-right">
-						<li><a class="default" href="{% url 'documents:publish' document.url_title 1 %}">{% trans "Publish for Students and University Network" %}</a></li>
-						<li><a href="{% url 'documents:publish' document.url_title 4 %}">{% trans "Publish for Students only" %}</a></li>
+						<li><a class="default" href="{% url document.get_publish_url_name document.url_title 1 %}">{% trans "Publish for Students and University Network" %}</a></li>
+						<li><a href="{% url document.get_publish_url_name document.url_title 4 %}">{% trans "Publish for Students only" %}</a></li>
 					  </ul>
 					</div>
 				{% endif %}
-				<a class="btn btn-sm btn-sidebar {% if active_page == 'versions' %}btn-warning{% else %}btn-default{% endif %}" href="{% url 'documents:versions' document.url_title %}" role="tab">{% trans "Versions" %}</a>
+				<a class="btn btn-sm btn-sidebar {% if active_page == 'versions' %}btn-warning{% else %}btn-default{% endif %}" href="{% url document.get_versions_url_name document.url_title %}" role="tab">{% trans "Versions" %}</a>
 			</div>
 			<div class="divider"></div>
 		{% endif %}

--- a/_1327/documents/urls.py
+++ b/_1327/documents/urls.py
@@ -16,6 +16,9 @@ urlpatterns = [
 	url(r"attachment/no-direct-download", views.change_attachment_no_direct_download, name='change_attachment_no_direct_download'),
 
 	url(r"(?P<document_type>[\w-]+)/create$", views.create, name='create'),
+]
+
+document_urlpatterns = [
 	url(r"(?P<title>[\w-]+)/edit$", views.edit, name='edit'),
 	url(r"(?P<title>[\w-]+)/autosave$", views.autosave, name='autosave'),
 	url(r"(?P<title>[\w-]+)/publish/(?P<state_id>[\d]+)$", views.publish, name='publish'),
@@ -25,5 +28,6 @@ urlpatterns = [
 	url(r"(?P<title>[\w-]+)/render$", views.render_text, name="render"),
 	url(r"(?P<title>[\w-]+)/delete-cascade$", views.get_delete_cascade, name="get_delete_cascade"),
 	url(r"(?P<title>[\w-]+)/delete$", views.delete_document, name="delete_document"),
-	url(r"(?P<title>[\w-]+)$", views.view, name='view'),
 ]
+
+urlpatterns.extend(document_urlpatterns)

--- a/_1327/documents/views.py
+++ b/_1327/documents/views.py
@@ -94,7 +94,7 @@ def edit(request, title, new_autosaved_pages=None, initial=None):
 
 	if success:
 		messages.success(request, _("Successfully saved changes"))
-		return HttpResponseRedirect(reverse('documents:view', args=[document.url_title]))
+		return HttpResponseRedirect(reverse(document.get_view_url_name(), args=[document.url_title]))
 	else:
 		return render(request, template_name, {
 			'document': document,
@@ -177,9 +177,9 @@ def permissions(request, title):
 		messages.success(request, _("Permissions have been changed successfully."))
 
 		if request.user.has_perm(document.edit_permission_name, document):
-			return HttpResponseRedirect(reverse('documents:permissions', args=[document.url_title]))
+			return HttpResponseRedirect(reverse(document.get_permissions_url_name(), args=[document.url_title]))
 		if request.user.has_perm(document.view_permission_name, document):
-			return HttpResponseRedirect(reverse('documents:view', args=[document.url_title]))
+			return HttpResponseRedirect(reverse(document.get_view_url_name(), args=[document.url_title]))
 		return HttpResponseRedirect(reverse('index'))
 
 	return render(request, 'documents_permissions.html', {
@@ -200,7 +200,7 @@ def publish(request, title, state_id):
 	document.publish(state_id)
 	messages.success(request, _("Minutes document has been published."))
 
-	return HttpResponseRedirect(reverse("documents:view", args=[document.url_title]))
+	return HttpResponseRedirect(reverse(document.get_view_url_name(), args=[document.url_title]))
 
 
 def attachments(request, title):
@@ -210,11 +210,11 @@ def attachments(request, title):
 	success, form, __ = handle_attachment(request, document)
 	if success:
 		messages.success(request, _("File has been uploaded successfully!"))
-		return HttpResponseRedirect(reverse("documents:attachments", args=[document.url_title]))
+		return HttpResponseRedirect(reverse(document.get_attachments_url_name(), args=[document.url_title]))
 	else:
 		return render(request, "documents_attachments.html", {
 			'document': document,
-			'edit_url': reverse('documents:attachments', args=[document.url_title]),
+			'edit_url': reverse(document.get_attachments_url_name(), args=[document.url_title]),
 			'form': form,
 			'attachments': document.attachments.all().order_by('index'),
 			'active_page': 'attachments',

--- a/_1327/information_pages/models.py
+++ b/_1327/information_pages/models.py
@@ -20,10 +20,10 @@ class InformationDocument(Document):
 		)
 
 	def get_view_url(self):
-		return reverse('documents:view', args=(self.url_title, ))
+		return reverse(self.get_view_url_name(), args=(self.url_title, ))
 
 	def get_edit_url(self):
-		return reverse('documents:edit', args=(self.url_title, ))
+		return reverse(self.get_edit_url_name(), args=(self.url_title, ))
 
 	def can_be_changed_by(self, user):
 		permission_name = self.edit_permission_name

--- a/_1327/main/views.py
+++ b/_1327/main/views.py
@@ -30,7 +30,7 @@ from .utils import save_footer_item_order, save_main_menu_item_order
 def index(request):
 	try:
 		document = Document.objects.get(id=settings.MAIN_PAGE_ID)
-		return HttpResponseRedirect(reverse('documents:view', args=[document.url_title]))
+		return HttpResponseRedirect(reverse(document.get_view_url_name(), args=[document.url_title]))
 
 		md = markdown.Markdown(safe_mode='escape', extensions=[TocExtension(baselevel=2), 'markdown.extensions.abbr'])
 		text = md.convert(document.text + abbreviation_explanation_markdown())

--- a/_1327/minutes/models.py
+++ b/_1327/minutes/models.py
@@ -80,10 +80,28 @@ class MinutesDocument(Document):
 		return slug_final
 
 	def get_view_url(self):
-		return reverse('documents:view', args=(self.url_title, ))
+		return reverse(self.get_view_url_name(), args=(self.url_title, ))
 
 	def get_edit_url(self):
-		return reverse('documents:edit', args=(self.url_title, ))
+		return reverse(self.get_edit_url_name(), args=(self.url_title, ))
+
+	def get_view_url_name(self):
+		return 'minutes:view'
+
+	def get_edit_url_name(self):
+		return 'minutes:edit'
+
+	def get_attachments_url_name(self):
+		return 'minutes:attachments'
+
+	def get_permissions_url_name(self):
+		return 'minutes:permissions'
+
+	def get_versions_url_name(self):
+		return 'minutes:versions'
+
+	def get_publish_url_name(self):
+		return 'minutes:publish'
 
 	def can_be_changed_by(self, user):
 		permission_name = self.edit_permission_name

--- a/_1327/minutes/tests.py
+++ b/_1327/minutes/tests.py
@@ -28,10 +28,10 @@ class TestEditor(WebTest):
 		"""
 		Test if the edit page shows the correct content
 		"""
-		response = self.app.get(reverse('documents:edit', args=[self.document.url_title]), expect_errors=True)
+		response = self.app.get(reverse(self.document.get_edit_url_name(), args=[self.document.url_title]), expect_errors=True)
 		self.assertEqual(response.status_code, 403)  # test anonymous user cannot access page
 
-		response = self.app.get(reverse('documents:edit', args=[self.document.url_title]), user=self.user)
+		response = self.app.get(reverse(self.document.get_edit_url_name(), args=[self.document.url_title]), user=self.user)
 		self.assertEqual(response.status_code, 200)
 
 		form = response.forms[0]
@@ -47,25 +47,25 @@ class TestEditor(WebTest):
 		"""
 		unpublished_document = mommy.make(MinutesDocument, participants=self.participants, moderator=self.moderator, state=MinutesDocument.UNPUBLISHED)
 		unpublished_document.set_all_permissions(Group.objects.get(name="Staff"))
-		response = self.app.get(reverse('documents:view', args=[unpublished_document.url_title]), user=self.user)
+		response = self.app.get(reverse(unpublished_document.get_view_url_name(), args=[unpublished_document.url_title]), user=self.user)
 		self.assertIn("Publish", response)
 		self.assertNotIn("Permissions", response)
 
 		published_document = mommy.make(MinutesDocument, participants=self.participants, moderator=self.moderator, state=MinutesDocument.PUBLISHED)
 		published_document.set_all_permissions(Group.objects.get(name="Staff"))
-		response = self.app.get(reverse('documents:view', args=[published_document.url_title]), user=self.user)
+		response = self.app.get(reverse(published_document.get_view_url_name(), args=[published_document.url_title]), user=self.user)
 		self.assertNotIn("Publish", response)
 		self.assertNotIn("Permissions", response)
 
 		internal_document = mommy.make(MinutesDocument, participants=self.participants, moderator=self.moderator, state=MinutesDocument.INTERNAL)
 		internal_document.set_all_permissions(Group.objects.get(name="Staff"))
-		response = self.app.get(reverse('documents:view', args=[internal_document.url_title]), user=self.user)
+		response = self.app.get(reverse(internal_document.get_view_url_name(), args=[internal_document.url_title]), user=self.user)
 		self.assertNotIn("Publish", response)
 		self.assertNotIn("Permissions", response)
 
 		custom_document = mommy.make(MinutesDocument, participants=self.participants, moderator=self.moderator, state=MinutesDocument.CUSTOM)
 		custom_document.set_all_permissions(Group.objects.get(name="Staff"))
-		response = self.app.get(reverse('documents:view', args=[custom_document.url_title]), user=self.user)
+		response = self.app.get(reverse(custom_document.get_view_url_name(), args=[custom_document.url_title]), user=self.user)
 		self.assertNotIn("Publish", response)
 		self.assertIn("Permissions", response)
 

--- a/_1327/minutes/urls.py
+++ b/_1327/minutes/urls.py
@@ -2,11 +2,13 @@ from django.conf.urls import url
 from django.contrib import admin
 
 from _1327.documents import urls as document_urls
+from _1327.documents import views as documents_views
 from . import views
 
 admin.autodiscover()
 
 urlpatterns = [
 	url(r"(?P<groupid>[\d]+)$", views.list, name='list'),
+	url(r"(?P<title>[\w-]+)/view$", documents_views.view, name='view'),
 ]
-urlpatterns.extend(document_urls.urlpatterns)
+urlpatterns.extend(document_urls.document_urlpatterns)

--- a/_1327/minutes/urls.py
+++ b/_1327/minutes/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url
 from django.contrib import admin
 
+from _1327.documents import urls as document_urls
 from . import views
 
 admin.autodiscover()
@@ -8,3 +9,4 @@ admin.autodiscover()
 urlpatterns = [
 	url(r"(?P<groupid>[\d]+)$", views.list, name='list'),
 ]
+urlpatterns.extend(document_urls.urlpatterns)

--- a/_1327/polls/models.py
+++ b/_1327/polls/models.py
@@ -74,10 +74,28 @@ class Poll(Document):
 		return Poll.get_vote_permission()
 
 	def get_view_url(self):
-		return reverse('documents:view', args=(self.url_title,))
+		return reverse(self.get_view_url_name(), args=(self.url_title,))
 
 	def get_edit_url(self):
-		return reverse('documents:edit', args=(self.url_title,))
+		return reverse(self.get_edit_url_name(), args=(self.url_title,))
+
+	def get_view_url_name(self):
+		return 'polls:view'
+
+	def get_edit_url_name(self):
+		return 'polls:edit'
+
+	def get_attachments_url_name(self):
+		return 'polls:attachments'
+
+	def get_permissions_url_name(self):
+		return 'polls:permissions'
+
+	def get_versions_url_name(self):
+		return 'polls:versions'
+
+	def get_publish_url_name(self):
+		return 'polls:publish'
 
 	def save_formset(self, formset):
 		choices = formset.save(commit=False)

--- a/_1327/polls/models.py
+++ b/_1327/polls/models.py
@@ -46,7 +46,7 @@ class Poll(Document):
 		def url(self, id):
 			poll = Poll.objects.get(id=id)
 			if poll:
-				return reverse('documents:view', args=[poll.id])
+				return reverse(poll.get_view_url_name(), args=[poll.id])
 			return ''
 
 	@classmethod

--- a/_1327/polls/templates/polls_index.html
+++ b/_1327/polls/templates/polls_index.html
@@ -33,7 +33,7 @@
 							<td class="text-right">
 								{% get_obj_perms request.user for poll as "poll_perms" %}
 								{% if "change_poll" in poll_perms %}
-									<a class="btn btn-warning btn-xs" href="{% url "documents:edit" poll.url_title %}">{% trans "Edit Poll" %}</a>
+									<a class="btn btn-warning btn-xs" href="{% url poll.get_edit_url_name poll.url_title %}">{% trans "Edit Poll" %}</a>
 								{% endif %}
 							</td>
 						</tr>
@@ -65,12 +65,12 @@
 				<tbody>
 					{% for poll in running_polls %}
 						<tr>
-							<td><a href="{% url "documents:view" poll.url_title %}">{{ poll.title }}</a></td>
+							<td><a href="{% url poll.get_view_url_name poll.url_title %}">{{ poll.title }}</a></td>
 							<td>{{ poll.start_date }} - {{ poll.end_date }}</td>
 							<td class="text-right">
 								{% get_obj_perms request.user for poll as "poll_perms" %}
 								{% if "change_poll" in poll_perms %}
-									<a class="btn btn-warning btn-xs" href="{% url "documents:edit" poll.url_title %}">{% trans "Edit Poll" %}</a>
+									<a class="btn btn-warning btn-xs" href="{% url poll.get_edit_url_name poll.url_title %}">{% trans "Edit Poll" %}</a>
 								{% endif %}
 							</td>
 						</tr>
@@ -103,7 +103,7 @@
 				{% for poll in finished_polls %}
 					<tr>
 						{% if poll|can_see_results %}
-							<td><a href="{% url "documents:view" poll.url_title %}">{{ poll.title }}</a></td>
+							<td><a href="{% url poll.get_view_url_name poll.url_title %}">{{ poll.title }}</a></td>
 						{% else %}
 							<td><span data-toggle="tooltip" data-placement="right" title="You can see the result of this Poll as from {{ poll.end_date|one_day_later }}.">{{ poll.title }} {% bootstrap_icon "info-sign" %}</span></td>
 						{% endif %}
@@ -111,7 +111,7 @@
 						<td class="text-right">
 							{% get_obj_perms request.user for poll as "poll_perms" %}
 							{% if "change_poll" in poll_perms %}
-								<a class="btn btn-warning btn-xs" href="{% url "documents:edit" poll.url_title %}">{% trans "Edit Poll" %}</a>
+								<a class="btn btn-warning btn-xs" href="{% url poll.get_edit_url_name poll.url_title %}">{% trans "Edit Poll" %}</a>
 							{% endif %}
 						</td>
 					</tr>

--- a/_1327/polls/templates/polls_vote.html
+++ b/_1327/polls/templates/polls_vote.html
@@ -15,7 +15,7 @@
 		</div>
 	{%  endif %}
 
-	<form action="{% url 'documents:view' document.url_title %}" method="post" class="form-horizontal" role="form">
+	<form action="{% url document.get_view_url_name document.url_title %}" method="post" class="form-horizontal" role="form">
 		{% csrf_token %}
 		<table class="table table-striped">
 			<tr>

--- a/_1327/polls/tests.py
+++ b/_1327/polls/tests.py
@@ -195,7 +195,7 @@ class PollViewTests(WebTest):
 		self.assertEqual(response.status_code, 403)
 
 	def test_edit_poll(self):
-		response = self.app.get(reverse('documents:edit', args=[self.poll.url_title]), user=self.user)
+		response = self.app.get(reverse(self.poll.get_edit_url_name(), args=[self.poll.url_title]), user=self.user)
 		self.assertEqual(response.status_code, 200)
 
 		choice_text = 'test choice'
@@ -223,7 +223,7 @@ class PollViewTests(WebTest):
 		self.assertEqual(poll.choices.last().description, choice_description)
 
 	def test_edit_poll_delete_choice(self):
-		response = self.app.get(reverse('documents:edit', args=[self.poll.url_title]), user=self.user)
+		response = self.app.get(reverse(self.poll.get_edit_url_name(), args=[self.poll.url_title]), user=self.user)
 		self.assertEqual(response.status_code, 200)
 
 		form = response.forms['document-form']
@@ -239,10 +239,10 @@ class PollViewTests(WebTest):
 	def test_edit_poll_user_has_no_permission(self):
 		user = mommy.make(UserProfile)
 
-		response = self.app.get(reverse('documents:edit', args=[self.poll.url_title]), user=user, expect_errors=True)
+		response = self.app.get(reverse(self.poll.get_edit_url_name(), args=[self.poll.url_title]), user=user, expect_errors=True)
 		self.assertEqual(response.status_code, 403)
 
-		response = self.app.post(reverse('documents:edit', args=[self.poll.url_title]), user=user, expect_errors=True)
+		response = self.app.post(reverse(self.poll.get_edit_url_name(), args=[self.poll.url_title]), user=user, expect_errors=True)
 		self.assertEqual(response.status_code, 403)
 
 	def test_deletion_no_superuser(self):
@@ -287,13 +287,13 @@ class PollResultTests(WebTest):
 		self.assign_vote_perm(user, obj)
 
 	def test_view_with_insufficient_permissions(self):
-		response = self.app.get(reverse('documents:view', args=[self.poll.url_title]), expect_errors=True)
+		response = self.app.get(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), expect_errors=True)
 		self.assertEqual(response.status_code, 403)
 
 	def test_view_result_without_vote(self):
 		user = mommy.make(UserProfile)
 		self.assign_view_vote_perms(user, self.poll)
-		response = self.app.get(reverse('documents:view', args=[self.poll.url_title]), user=user)
+		response = self.app.get(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), user=user)
 		self.assertTemplateUsed(response, 'polls_vote.html')
 
 	def test_view_after_vote(self):
@@ -301,7 +301,7 @@ class PollResultTests(WebTest):
 		self.assign_view_vote_perms(user, self.poll)
 		self.poll.participants.add(user)
 
-		response = self.app.get(reverse('documents:view', args=[self.poll.url_title]), user=user)
+		response = self.app.get(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), user=user)
 		self.assertEqual(response.status_code, 200)
 		self.assertTemplateUsed(response, 'polls_results.html')
 
@@ -317,7 +317,7 @@ class PollResultTests(WebTest):
 		self.poll.participants.add(user)
 		self.poll.save()
 
-		response = self.app.get(reverse('documents:view', args=[self.poll.url_title]), user=user)
+		response = self.app.get(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), user=user)
 		self.assertEqual(response.status_code, 200)
 		self.assertIn(self.poll.text, response.body)
 
@@ -327,7 +327,7 @@ class PollResultTests(WebTest):
 		self.poll.start_date += datetime.timedelta(weeks=1)
 		self.poll.save()
 
-		response = self.app.get(reverse('documents:view', args=[self.poll.url_title]), user=user)
+		response = self.app.get(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), user=user)
 		self.assertEqual(response.status_code, 200)
 		self.assertTemplateUsed(response, 'polls_index.html')
 
@@ -335,7 +335,7 @@ class PollResultTests(WebTest):
 		user = mommy.make(UserProfile)
 		self.assign_view_perm(user, self.poll)
 
-		response = self.app.get(reverse('documents:view', args=[self.poll.url_title]), user=user, expect_errors=True)
+		response = self.app.get(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), user=user, expect_errors=True)
 		self.assertEqual(response.status_code, 200)
 		self.assertTemplateUsed(response, 'polls_results.html')
 
@@ -343,7 +343,7 @@ class PollResultTests(WebTest):
 		user = mommy.make(UserProfile)
 		self.assign_view_perm(user, self.poll)
 
-		response = self.app.get(reverse('documents:view', args=[self.poll.url_title]), user=user, expect_errors=True)
+		response = self.app.get(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), user=user, expect_errors=True)
 		self.assertEqual(response.status_code, 200)
 		self.assertTemplateUsed(response, 'polls_results.html')
 
@@ -366,25 +366,25 @@ class PollVoteTests(WebTest):
 		)
 
 	def test_vote_with_insufficient_permissions(self):
-		response = self.app.get(reverse('documents:view', args=[self.poll.url_title]), expect_errors=True)
+		response = self.app.get(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), expect_errors=True)
 		self.assertEqual(response.status_code, 403)
 
 		user = mommy.make(UserProfile)
 		assign_perm(Poll.VIEW_PERMISSION_NAME, user, self.poll)
 
-		response = self.app.get(reverse('documents:view', args=[self.poll.url_title]), user=user, expect_errors=True)
+		response = self.app.get(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), user=user, expect_errors=True)
 		self.assertEqual(response.status_code, 200)
 		self.assertTemplateUsed(response, 'polls_results.html')
 
 	def test_vote_with_sufficient_permissions(self):
-		response = self.app.get(reverse('documents:view', args=[self.poll.url_title]), user=self.user)
+		response = self.app.get(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), user=self.user)
 		self.assertEqual(response.status_code, 200)
 
 		user = mommy.make(UserProfile)
 		assign_perm(Poll.VIEW_PERMISSION_NAME, user, self.poll)
 		assign_perm('vote_poll', user, self.poll)
 		user.save()
-		response = self.app.get(reverse('documents:view', args=[self.poll.url_title]), user=user)
+		response = self.app.get(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), user=user)
 		self.assertEqual(response.status_code, 200)
 		self.assertTemplateUsed(response, 'polls_vote.html')
 
@@ -392,23 +392,23 @@ class PollVoteTests(WebTest):
 		self.poll.end_date = datetime.date.today() - datetime.timedelta(days=1)
 		self.poll.save()
 
-		response = self.app.get(reverse('documents:view', args=[self.poll.url_title]), user=self.user)
+		response = self.app.get(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), user=self.user)
 		self.assertTemplateUsed(response, 'polls_results.html')
 
 	def test_vote_poll_already_voted(self):
 		self.poll.participants.add(self.user)
 		self.poll.save()
 
-		response = self.app.get(reverse('documents:view', args=[self.poll.url_title]), user=self.user)
+		response = self.app.get(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), user=self.user)
 		self.assertTemplateUsed(response, 'polls_results.html')
-		response = self.app.post(reverse('documents:view', args=[self.poll.url_title]), user=self.user)
+		response = self.app.post(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), user=self.user)
 		self.assertTemplateUsed(response, 'polls_results.html')
 
 	def test_start_vote_multiple_choice_poll(self):
 		self.poll.max_allowed_number_of_answers = 2
 		self.poll.save()
 
-		response = self.app.get(reverse('documents:view', args=[self.poll.url_title]), user=self.user)
+		response = self.app.get(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), user=self.user)
 		self.assertEqual(response.status_code, 200)
 		self.assertIn(b"checkbox", response.body)
 		self.assertNotIn(b"radio", response.body)
@@ -417,20 +417,20 @@ class PollVoteTests(WebTest):
 		self.poll.max_allowed_number_of_answers = 1
 		self.poll.save()
 
-		response = self.app.get(reverse('documents:view', args=[self.poll.url_title]), user=self.user)
+		response = self.app.get(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), user=self.user)
 		self.assertEqual(response.status_code, 200)
 		self.assertIn(b"radio", response.body)
 		self.assertNotIn(b"checkbox", response.body)
 
 	def test_choices_in_response(self):
-		response = self.app.get(reverse('documents:view', args=[self.poll.url_title]), user=self.user)
+		response = self.app.get(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), user=self.user)
 		self.assertEqual(response.status_code, 200)
 		for choice in self.poll.choices.all():
 			self.assertIn(choice.text.encode('utf-8'), response.body)
 
 	def test_vote_without_submitting_a_choice(self):
-		response = self.app.post(reverse('documents:view', args=[self.poll.url_title]), user=self.user)
-		self.assertRedirects(response, reverse('documents:view', args=[self.poll.url_title]))
+		response = self.app.post(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), user=self.user)
+		self.assertRedirects(response, reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]))
 
 	def test_vote_single_choice_submitting_more_than_one_choice(self):
 		self.poll.max_allowed_number_of_answers = 1
@@ -440,8 +440,8 @@ class PollVoteTests(WebTest):
 		for choice in self.poll.choices.all():
 			data.append(('choice', choice.id))
 
-		response = self.app.post(reverse('documents:view', args=[self.poll.url_title]), params=data, user=self.user)
-		self.assertRedirects(response, reverse('documents:view', args=[self.poll.url_title]))
+		response = self.app.post(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), params=data, user=self.user)
+		self.assertRedirects(response, reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]))
 
 	def test_vote_single_choice_correctly(self):
 		self.poll.max_allowed_number_of_answers = 1
@@ -451,7 +451,7 @@ class PollVoteTests(WebTest):
 		data = [('choice', choice.id)]
 		votes = choice.votes
 
-		response = self.app.post(reverse('documents:view', args=[self.poll.url_title]), params=data, user=self.user)
+		response = self.app.post(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), params=data, user=self.user)
 		self.assertEqual(response.status_code, 302)
 
 		choice = self.poll.choices.first()
@@ -470,7 +470,7 @@ class PollVoteTests(WebTest):
 			data.append(('choice', choice.id))
 			votes.append(choice.votes)
 
-		response = self.app.post(reverse('documents:view', args=[self.poll.url_title]), params=data, user=self.user)
+		response = self.app.post(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), params=data, user=self.user)
 		self.assertEqual(response.status_code, 302)
 		for i, choice in enumerate(self.poll.choices.all()):
 			self.assertEqual(choice.votes, votes[i] + 1)
@@ -483,7 +483,7 @@ class PollVoteTests(WebTest):
 		self.poll.start_date += datetime.timedelta(weeks=1)
 		self.poll.save()
 
-		response = self.app.get(reverse('documents:view', args=[self.poll.url_title]), user=self.user)
+		response = self.app.get(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), user=self.user)
 		self.assertEqual(response.status_code, 200)
 		self.assertTemplateUsed(response, 'polls_index.html')
 
@@ -492,21 +492,21 @@ class PollVoteTests(WebTest):
 		self.poll.show_results_immediately = True
 		self.poll.save()
 
-		response = self.app.get(reverse('documents:view', args=[self.poll.url_title]), user=self.user)
+		response = self.app.get(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), user=self.user)
 		self.assertEqual(response.status_code, 200)
 		self.assertTemplateUsed(response, 'polls_results.html')
 
 		self.poll.show_results_immediately = False
 		self.poll.save()
 
-		response = self.app.get(reverse('documents:view', args=[self.poll.url_title]), user=self.user)
+		response = self.app.get(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), user=self.user)
 		self.assertRedirects(response, reverse('polls:index'))
 
 	def test_vote_poll_with_results_that_can_not_be_seen_immediately(self):
 		self.poll.show_results_immediately = False
 		self.poll.save()
 
-		response = self.app.get(reverse('documents:view', args=[self.poll.url_title]), user=self.user)
+		response = self.app.get(reverse(self.poll.get_view_url_name(), args=[self.poll.url_title]), user=self.user)
 		self.assertEqual(response.status_code, 200)
 		self.assertTemplateUsed(response, 'polls_vote.html')
 
@@ -556,7 +556,7 @@ class PollEditTests(WebTest):
 		self.assertEqual(response.status_code, 200)
 
 	def test_submit_with_too_few_forms(self):
-		response = self.app.get(reverse('documents:edit', args=[self.poll.url_title]), user=self.user)
+		response = self.app.get(reverse(self.poll.get_edit_url_name(), args=[self.poll.url_title]), user=self.user)
 		self.assertEqual(response.status_code, 200)
 
 		form = response.forms['document-form']
@@ -580,7 +580,7 @@ class PollEditTests(WebTest):
 		self.assertEqual(Choice.objects.filter(poll=self.poll).count(), 3)
 
 	def test_submit_with_sufficient_forms(self):
-		response = self.app.get(reverse('documents:edit', args=[self.poll.url_title]), user=self.user)
+		response = self.app.get(reverse(self.poll.get_edit_url_name(), args=[self.poll.url_title]), user=self.user)
 
 		form = response.forms['document-form']
 		form['comment'] = 'sample comment'
@@ -592,7 +592,7 @@ class PollEditTests(WebTest):
 		self.assertEqual(Choice.objects.filter(poll=self.poll).count(), 2)
 
 	def test_submit_more_forms(self):
-		response = self.app.get(reverse('documents:edit', args=[self.poll.url_title]), user=self.user)
+		response = self.app.get(reverse(self.poll.get_edit_url_name(), args=[self.poll.url_title]), user=self.user)
 
 		form = response.forms['document-form']
 		form['comment'] = 'sample comment'

--- a/_1327/polls/urls.py
+++ b/_1327/polls/urls.py
@@ -1,7 +1,9 @@
 from django.conf.urls import url
 
+from _1327.documents import urls as document_urls
 from . import views
 
 urlpatterns = [
 	url(r"^$", views.index, name="index"),
 ]
+urlpatterns.extend(document_urls.urlpatterns)

--- a/_1327/polls/urls.py
+++ b/_1327/polls/urls.py
@@ -5,5 +5,6 @@ from . import views
 
 urlpatterns = [
 	url(r"^$", views.index, name="index"),
+	url(r"(?P<title>[\w-]+)/view$", views.view, name='view'),
 ]
-urlpatterns.extend(document_urls.urlpatterns)
+urlpatterns.extend(document_urls.document_urlpatterns)

--- a/_1327/polls/views.py
+++ b/_1327/polls/views.py
@@ -93,10 +93,10 @@ def vote(request, poll, url_title):
 		choices = request.POST.getlist('choice')
 		if len(choices) == 0:
 			messages.error(request, _("You must select one Choice at least!"))
-			return HttpResponseRedirect(reverse('documents:view', args=[url_title]))
+			return HttpResponseRedirect(reverse(poll.get_view_url_name(), args=[url_title]))
 		if len(choices) > poll.max_allowed_number_of_answers:
 			messages.error(request, _("You can only select up to {} options!").format(poll.max_allowed_number_of_answers))
-			return HttpResponseRedirect(reverse('documents:view', args=[url_title]))
+			return HttpResponseRedirect(reverse(poll.get_view_url_name(), args=[url_title]))
 
 		for choice_id in choices:
 			choice = poll.choices.filter(id=choice_id)
@@ -107,7 +107,7 @@ def vote(request, poll, url_title):
 		if not poll.show_results_immediately:
 			messages.info(request, _("The results of this poll will be available as from {}".format((poll.end_date + datetime.timedelta(days=1)).strftime("%d. %B %Y"))))
 			return HttpResponseRedirect(reverse('polls:index'))
-		return HttpResponseRedirect(reverse('documents:view', args=[url_title]))
+		return HttpResponseRedirect(reverse(poll.get_view_url_name(), args=[url_title]))
 
 	md = markdown.Markdown(safe_mode='escape', extensions=[TocExtension(baselevel=2), InternalLinksMarkdownExtension(), 'markdown.extensions.abbr'])
 	description = md.convert(poll.text + abbreviation_explanation_markdown())

--- a/_1327/settings.py
+++ b/_1327/settings.py
@@ -42,6 +42,9 @@ ANONYMOUS_IP_RANGE_GROUPS = {
 	# Example: '127.0.0.0/8': UNIVERSITY_GROUP_NAME,
 }
 
+MINUTES_URL_NAME = "minutes"
+POLLS_URL_NAME = "polls"
+
 
 # Application definition
 

--- a/_1327/urls.py
+++ b/_1327/urls.py
@@ -2,6 +2,8 @@ from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
 
+from _1327.documents import urls as document_urls
+from _1327.documents import views as documents_views
 from _1327.main import views as main_views
 from _1327.user_management import views as user_management_views
 
@@ -28,3 +30,7 @@ urlpatterns = [
 	url(r'^admin/', include(admin.site.urls)),
 	url(r'^hijack/', include('hijack.urls')),
 ]
+urlpatterns.extend(document_urls.document_urlpatterns)
+urlpatterns.extend([
+	url(r"(?P<title>[\w-]+)$", documents_views.view, name='view'),
+])

--- a/_1327/urls.py
+++ b/_1327/urls.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
 
@@ -8,13 +9,13 @@ admin.autodiscover()
 
 urlpatterns = [
 	url(r"^$", main_views.index, name='index'),
+	url(r"^" + settings.MINUTES_URL_NAME + "/", include('_1327.minutes.urls', namespace='minutes')),
+	url(r"^" + settings.POLLS_URL_NAME + "/", include('_1327.polls.urls', namespace='polls')),
 	url(r"^documents/", include('_1327.documents.urls', namespace='documents')),
 	url(r"^information_pages/", include('_1327.information_pages.urls', namespace='information_pages')),
-	url(r"^minutes/", include('_1327.minutes.urls', namespace='minutes')),
 	url(r"^login$", user_management_views.login, name='login'),
 	url(r"^logout$", user_management_views.logout, name='logout'),
 	url(r'^view_as$', user_management_views.view_as, name='view_as'),
-	url(r'^polls/', include('_1327.polls.urls', namespace='polls')),
 
 	url(r'^abbreviation_explanation/', main_views.abbreviation_explanation_edit, name="abbreviation_explanation"),
 

--- a/_1327/user_management/tests.py
+++ b/_1327/user_management/tests.py
@@ -123,14 +123,14 @@ class _1327AuthenticationBackendTests(WebTest):
 		for group in anonymous_groups:
 			assign_perm(self.document.view_permission_name, group, self.document)
 
-		response = self.app.get(reverse('documents:view', args=[self.document.url_title]), user=self.user)
+		response = self.app.get(reverse(self.document.get_view_url_name(), args=[self.document.url_title]), user=self.user)
 		self.assertEqual(response.status_code, 200)
 
 	def test_anonymous_fallback_without_anonymous_permission(self):
 		for group in Group.objects.all().exclude(name=settings.ANONYMOUS_GROUP_NAME):
 			assign_perm(self.document.view_permission_name, group, self.document)
 
-		response = self.app.get(reverse('documents:view', args=[self.document.url_title]), expect_errors=True, user=self.user)
+		response = self.app.get(reverse(self.document.get_view_url_name(), args=[self.document.url_title]), expect_errors=True, user=self.user)
 		self.assertEqual(response.status_code, 403)
 
 	def test_anonymous_fallback_not_used_if_user_has_permission(self):
@@ -140,7 +140,7 @@ class _1327AuthenticationBackendTests(WebTest):
 
 		assign_perm(self.document.view_permission_name, group, self.document)
 
-		response = self.app.get(reverse('documents:view', args=[self.document.url_title]), user=self.user)
+		response = self.app.get(reverse(self.document.get_view_url_name(), args=[self.document.url_title]), user=self.user)
 		self.assertEqual(response.status_code, 200)
 
 	def test_university_network_fallback_no_access(self):
@@ -155,7 +155,7 @@ class _1327AuthenticationBackendTests(WebTest):
 		}
 
 		with self.settings(**university_group_setting):
-			response = self.app.get(reverse('documents:view', args=[self.document.url_title]), expect_errors=True)
+			response = self.app.get(reverse(self.document.get_view_url_name(), args=[self.document.url_title]), expect_errors=True)
 			self.assertEqual(response.status_code, 403)
 
 	def test_university_network_fallback_access_granted(self):
@@ -173,7 +173,7 @@ class _1327AuthenticationBackendTests(WebTest):
 			# mimic that the user is in the university network
 			request_meta = {'REMOTE_ADDR': '8.0.0.1'}
 
-			response = self.app.get(reverse('documents:view', args=[self.document.url_title]), extra_environ=request_meta)
+			response = self.app.get(reverse(self.document.get_view_url_name(), args=[self.document.url_title]), extra_environ=request_meta)
 			self.assertEqual(response.status_code, 200)
 
 	def test_university_network_fallback_university_network_no_access(self):
@@ -190,7 +190,7 @@ class _1327AuthenticationBackendTests(WebTest):
 			request_meta = {'REMOTE_ADDR': '8.0.0.1'}
 
 			response = self.app.get(
-				reverse('documents:view', args=[self.document.url_title]),
+				reverse(self.document.get_view_url_name(), args=[self.document.url_title]),
 				extra_environ=request_meta,
 				expect_errors=True,
 			)


### PR DESCRIPTION
fix #456
- use `/minutes/...` for minutes documents and `/polls/...` for polls instead of `/documents/...`
- use `/url_title` for information_documents