### PR TITLE
Sort polls by end date

### DIFF
--- a/_1327/polls/views.py
+++ b/_1327/polls/views.py
@@ -24,7 +24,7 @@ def index(request):
 	finished_polls = []
 	upcoming_polls = []
 	# do not show polls that a user is not allowed to see
-	for poll in Poll.objects.all():
+	for poll in Poll.objects.all().order_by('-end_date'):
 		if request.user.has_perm(Poll.get_view_permission(), obj=poll) and poll.start_date <= datetime.date.today():
 			if datetime.date.today() <= poll.end_date \
 						and not poll.participants.filter(id=request.user.pk).exists() \


### PR DESCRIPTION
This solves #429 and additionally reduces the number of SQL queries in the polls index list by a lot.

Is there a better/cleaner way to pass the attribute (whether the poll can be changed by the user) to the view?