### PR TITLE
Permission info

### DIFF
--- a/_1327/documents/templates/documents_base.html
+++ b/_1327/documents/templates/documents_base.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load bootstrap3 %}
 {% load document_perms %}
+{% load morefilters %}
 
 {% block title %}
 	{{ document.title }}
@@ -11,28 +12,39 @@
 	{{ document.meta_information_html }}
 	<div class="divider hidden-print"></div>
 	{% block document_nav %}
-		{% get_obj_perms request.user for document as "document_perms" %}
-		{% if "change" in document_perms %}
+		{% if can_edit %}
 			<div role="tablist" class="hidden-print">
 				<a class="btn btn-sm btn-sidebar {% if active_page == 'view' %}btn-warning{% else %}btn-default{% endif %}" href="{% url document.get_view_url_name document.url_title %}" role="tab">{% trans "View" %}</a>
 				<a class="btn btn-sm btn-sidebar {% if active_page == 'edit' %}btn-warning{% else %}btn-default{% endif %}" href="{% url document.get_edit_url_name document.url_title %}" role="tab">{% trans "Edit" %}</a>
 				<a class="btn btn-sm btn-sidebar {% if active_page == 'attachments' %}btn-warning{% else %}btn-default{% endif %}" href="{% url document.get_attachments_url_name document.url_title %}" role="tab">{% trans "Attachments" %}</a>
-				{% if document.show_permissions_editor %}<a class="btn btn-sm btn-sidebar {% if active_page == 'permissions' %}btn-warning{% else %}btn-default{% endif %}" href="{% url document.get_permissions_url_name document.url_title %}" role="tab" {% if permission_warning %}data-toggle="tooltip" data-placement="left" data-container="body" title="{% trans "Anonymous users are not allowed to see this site!" %}" {% endif %}>{% if permission_warning %}<span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span> {% endif %}{% trans "Permissions" %}</a>{% endif %}
-				{% if document.show_publish_button %}
-					<div class="btn-group btn-sidebar">
-					  <a class="btn btn-sm btn-default col-xs-9" href="{% url document.get_publish_url_name document.url_title 1 %}" role="tab">{% trans "Publish" %}</a>
-					  <button type="button" class="btn btn-sm btn-default col-xs-3 dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-						<span class="caret"></span>
-						<span class="sr-only">Toggle Dropdown</span>
-					  </button>
-					  <ul class="dropdown-menu dropdown-menu-right">
-						<li><a class="default" href="{% url document.get_publish_url_name document.url_title 1 %}">{% trans "Publish for Students and University Network" %}</a></li>
-						<li><a href="{% url document.get_publish_url_name document.url_title 4 %}">{% trans "Publish for Students only" %}</a></li>
-					  </ul>
-					</div>
-				{% endif %}
 				<a class="btn btn-sm btn-sidebar {% if active_page == 'versions' %}btn-warning{% else %}btn-default{% endif %}" href="{% url document.get_versions_url_name document.url_title %}" role="tab">{% trans "Versions" %}</a>
 			</div>
+			<div class="divider"></div>
+			{% if document.show_permissions_editor %}<a class="btn btn-sm btn-sidebar {% if active_page == 'permissions' %}btn-warning{% else %}btn-default{% endif %}" href="{% url document.get_permissions_url_name document.url_title %}" role="tab">{% trans "Permissions" %}</a>{% endif %}
+			{% if document.show_publish_button %}
+				<div class="btn-group btn-sidebar">
+					<a class="btn btn-sm btn-default col-xs-9" href="{% url document.get_publish_url_name document.url_title 1 %}" role="tab">{% trans "Publish" %}</a>
+					<button type="button" class="btn btn-sm btn-default col-xs-3 dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+						<span class="caret"></span>
+						<span class="sr-only">Toggle Dropdown</span>
+					</button>
+					<ul class="dropdown-menu dropdown-menu-right">
+						<li><a class="default" href="{% url document.get_publish_url_name document.url_title 1 %}">{% trans "Publish for Students and University Network" %}</a></li>
+						<li><a href="{% url document.get_publish_url_name document.url_title 4 %}">{% trans "Publish for Students only" %}</a></li>
+					</ul>
+				</div>
+			{% endif %}
+			{% with edit_groups=permission_overview|permission_filter:'edit'|join:', ' view_groups=permission_overview|permission_filter:'view'|join:', '%}
+				<div class="permission-icons" data-toggle="tooltip" data-placement="top" data-container="body" data-html="true" title="<b>{% trans 'Edit' %}:</b> {% if edit_groups %}{{ edit_groups }}{% else %}&mdash;{% endif %}</br><b>{% trans 'View' %}:</b> {% if view_groups %}{{ view_groups }}{% else %}&mdash;{% endif %}">
+					<span class="glyphicon glyphicon-globe permission-icon-{{ permission_overview.0.1 }}" aria-hidden="true"></span>
+					<span class="glyphicon glyphicon-education permission-icon-{{ permission_overview.1.1 }}" aria-hidden="true"></span>
+					<span class="glyphicon glyphicon-user permission-icon-{{ permission_overview.2.1 }}" aria-hidden="true"></span>
+					<span class="glyphicon glyphicon-briefcase permission-icon-{{ permission_overview.3.1 }}" aria-hidden="true"></span>
+					{% if permission_overview|length > 4 %}
+						<span class="glyphicon glyphicon-option-horizontal permission-icon-more" aria-hidden="true"></span>
+					{% endif %}<br/>
+				</div>
+			{% endwith %}
 			<div class="divider"></div>
 		{% endif %}
 	{% endblock %}

--- a/_1327/documents/templates/documents_base.html
+++ b/_1327/documents/templates/documents_base.html
@@ -12,7 +12,7 @@
 	{{ document.meta_information_html }}
 	<div class="divider hidden-print"></div>
 	{% block document_nav %}
-		{% if can_edit %}
+		{% if permission_overview %}
 			<div role="tablist" class="hidden-print">
 				<a class="btn btn-sm btn-sidebar {% if active_page == 'view' %}btn-warning{% else %}btn-default{% endif %}" href="{% url document.get_view_url_name document.url_title %}" role="tab">{% trans "View" %}</a>
 				<a class="btn btn-sm btn-sidebar {% if active_page == 'edit' %}btn-warning{% else %}btn-default{% endif %}" href="{% url document.get_edit_url_name document.url_title %}" role="tab">{% trans "Edit" %}</a>

--- a/_1327/documents/utils.py
+++ b/_1327/documents/utils.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
 from django.utils import timezone
-from guardian.utils import get_anonymous_user
 from reversion import revisions
 
 from _1327.documents.forms import AttachmentForm, DocumentForm
@@ -141,12 +140,6 @@ def handle_attachment(request, document):
 	else:
 		form = AttachmentForm()
 	return False, form, None
-
-
-def permission_warning(user, document):
-	anonymous_rights = get_anonymous_user().has_perm(document.view_permission_name, document)
-	edit_rights = user.has_perm(document.edit_permission_name, document)
-	return edit_rights and not anonymous_rights
 
 
 @lru_cache(maxsize=32)

--- a/_1327/documents/views.py
+++ b/_1327/documents/views.py
@@ -31,7 +31,7 @@ from _1327.documents.utils import delete_cascade_to_json, delete_old_empty_pages
 	handle_attachment, handle_autosave, handle_edit, prepare_versions
 from _1327.information_pages.models import InformationDocument
 from _1327.information_pages.forms import InformationDocumentForm  # noqa
-from _1327.main.utils import abbreviation_explanation_markdown, get_permission_overview
+from _1327.main.utils import abbreviation_explanation_markdown, document_permission_overview
 from _1327.minutes.models import MinutesDocument
 from _1327.minutes.forms import MinutesDocumentForm  # noqa
 from _1327.polls.models import Poll
@@ -106,8 +106,7 @@ def edit(request, title, new_autosaved_pages=None, initial=None):
 			'active_page': 'edit',
 			'creation': document.is_in_creation,
 			'new_autosaved_pages': new_autosaved_pages,
-			'can_edit': True,
-			'permission_overview': get_permission_overview(document),
+			'permission_overview': document_permission_overview(request.user, document),
 			'supported_image_types': settings.SUPPORTED_IMAGE_TYPES,
 			'formset': formset,
 		})
@@ -145,8 +144,7 @@ def versions(request, title):
 		'active_page': 'versions',
 		'versions': document_versions,
 		'document': document,
-		'can_edit': True,
-		'permission_overview': get_permission_overview(document),
+		'permission_overview': document_permission_overview(request.user, document),
 		'can_be_reverted': document.can_be_reverted,
 	})
 
@@ -165,11 +163,6 @@ def view(request, title):
 	md = markdown.Markdown(safe_mode='escape', extensions=[TocExtension(baselevel=2), InternalLinksMarkdownExtension(), 'markdown.extensions.abbr', 'markdown.extensions.tables'])
 	text = md.convert(document.text + abbreviation_explanation_markdown())
 
-	can_edit = request.user.has_perm(document.edit_permission_name, document)
-	permission_overview = []
-	if can_edit:
-		permission_overview = get_permission_overview(document)
-
 	return render(request, 'documents_base.html', {
 		'document': document,
 		'text': text,
@@ -177,8 +170,7 @@ def view(request, title):
 		'attachments': document.attachments.filter(no_direct_download=False).order_by('index'),
 		'active_page': 'view',
 		'view_page': True,
-		'can_edit': can_edit,
-		'permission_overview': permission_overview,
+		'permission_overview': document_permission_overview(request.user, document),
 	})
 
 
@@ -209,8 +201,7 @@ def permissions(request, title):
 		'formset_header': PermissionForm.header(content_type),
 		'formset': formset,
 		'active_page': 'permissions',
-		'can_edit': True,
-		'permission_overview': get_permission_overview(document),
+		'permission_overview': document_permission_overview(request.user, document),
 	})
 
 
@@ -241,8 +232,7 @@ def attachments(request, title):
 			'form': form,
 			'attachments': document.attachments.all().order_by('index'),
 			'active_page': 'attachments',
-			'can_edit': True,
-			'permission_overview': get_permission_overview(document),
+			'permission_overview': document_permission_overview(request.user, document),
 		})
 
 

--- a/_1327/main/templatetags/morefilters.py
+++ b/_1327/main/templatetags/morefilters.py
@@ -29,3 +29,8 @@ def can_view_menu_item(menu_item, user):
 @register.filter(name='sort_users_by_name')
 def sort_users_by_name(users):
 	return sorted(users, key=lambda user: ((user.last_name or "").lower(), (user.first_name or "").lower(), (user.get_full_name() or "").lower()))
+
+
+@register.filter(name='permission_filter')
+def permission_filter(permission_overview, permission_name):
+	return [group for group, permission in permission_overview if permission == permission_name]

--- a/_1327/main/utils.py
+++ b/_1327/main/utils.py
@@ -100,7 +100,11 @@ def slugify_and_clean_url_title(instance, url_title):
 	return url_title
 
 
-def get_permission_overview(document):
+def document_permission_overview(user, document):
+	can_edit = user.has_perm(document.edit_permission_name, document)
+	if not can_edit:
+		return []
+
 	main_groups = [
 		settings.ANONYMOUS_GROUP_NAME,
 		settings.UNIVERSITY_GROUP_NAME,

--- a/_1327/main/views.py
+++ b/_1327/main/views.py
@@ -20,7 +20,7 @@ from _1327.documents.models import Document
 from _1327.documents.views import edit as document_edit, view as document_view
 from _1327.main.forms import AbbreviationExplanationForm, get_permission_form
 from _1327.main.models import AbbreviationExplanation
-from _1327.main.utils import abbreviation_explanation_markdown, find_root_menu_items, get_permission_overview
+from _1327.main.utils import abbreviation_explanation_markdown, document_permission_overview, find_root_menu_items
 from _1327.shortlinks.models import Shortlink
 from _1327.shortlinks.views import edit as shortlink_edit, view as shortlink_view
 from .forms import MenuItemAdminForm, MenuItemCreationAdminForm, MenuItemCreationForm, MenuItemForm
@@ -36,11 +36,6 @@ def index(request):
 		md = markdown.Markdown(safe_mode='escape', extensions=[TocExtension(baselevel=2), 'markdown.extensions.abbr', 'markdown.extensions.tables'])
 		text = md.convert(document.text + abbreviation_explanation_markdown())
 
-		can_edit = request.user.has_perm(document.edit_permission_name, document)
-		permission_overview = []
-		if can_edit:
-			permission_overview = get_permission_overview(document)
-
 		template = 'information_pages_base.html' if document.polymorphic_ctype.model == 'informationdocument' else 'minutes_base.html'
 		return render(request, template, {
 			'document': document,
@@ -49,8 +44,7 @@ def index(request):
 			'attachments': document.attachments.filter(no_direct_download=False).order_by('index'),
 			'active_page': 'view',
 			'view_page': True,
-			'can_edit': can_edit,
-			'permission_overview': permission_overview,
+			'permission_overview': document_permission_overview(request.user, document),
 		})
 	except ObjectDoesNotExist:
 		# nobody created a mainpage yet -> show default main page

--- a/_1327/main/views.py
+++ b/_1327/main/views.py
@@ -17,11 +17,10 @@ import markdown
 from markdown.extensions.toc import TocExtension
 
 from _1327.documents.models import Document
-from _1327.documents.utils import permission_warning
 from _1327.documents.views import edit as document_edit, view as document_view
 from _1327.main.forms import AbbreviationExplanationForm, get_permission_form
 from _1327.main.models import AbbreviationExplanation
-from _1327.main.utils import abbreviation_explanation_markdown, find_root_menu_items
+from _1327.main.utils import abbreviation_explanation_markdown, find_root_menu_items, get_permission_overview
 from _1327.shortlinks.models import Shortlink
 from _1327.shortlinks.views import edit as shortlink_edit, view as shortlink_view
 from .forms import MenuItemAdminForm, MenuItemCreationAdminForm, MenuItemCreationForm, MenuItemForm
@@ -37,6 +36,11 @@ def index(request):
 		md = markdown.Markdown(safe_mode='escape', extensions=[TocExtension(baselevel=2), 'markdown.extensions.abbr', 'markdown.extensions.tables'])
 		text = md.convert(document.text + abbreviation_explanation_markdown())
 
+		can_edit = request.user.has_perm(document.edit_permission_name, document)
+		permission_overview = []
+		if can_edit:
+			permission_overview = get_permission_overview(document)
+
 		template = 'information_pages_base.html' if document.polymorphic_ctype.model == 'informationdocument' else 'minutes_base.html'
 		return render(request, template, {
 			'document': document,
@@ -45,7 +49,8 @@ def index(request):
 			'attachments': document.attachments.filter(no_direct_download=False).order_by('index'),
 			'active_page': 'view',
 			'view_page': True,
-			'permission_warning': permission_warning(request.user, document),
+			'can_edit': can_edit,
+			'permission_overview': permission_overview,
 		})
 	except ObjectDoesNotExist:
 		# nobody created a mainpage yet -> show default main page

--- a/_1327/minutes/templates/minutes_list.html
+++ b/_1327/minutes/templates/minutes_list.html
@@ -22,16 +22,27 @@
 			{% for minute in minutes %}
 				<tr>
 					<td class="col-xs-2">
-						<a href="{{ minute.get_view_url }}">{{ minute.date | date:"d.m.Y" }}</td></a>
-					<td class="col-xs-3">
+						<a href="{{ minute.get_view_url }}">{{ minute.date | date:"d.m.Y" }}</a>
+					</td>
+					{% if own_group %}
+						<td class="col-xs-1" style="text-align: center; font-weight: lighter;">
+							{% if minute.state == minute.UNPUBLISHED %}
+								<span class="text-red" data-toggle="tooltip" data-placement="top" data-container="body" title="{% trans 'Unpublished' %}"><span class="glyphicon glyphicon-alert" aria-hidden="true"></span></span>
+							{% elif minute.state == minute.INTERNAL %}
+								<span class="text-yellow" data-toggle="tooltip" data-placement="top" data-container="body" title="{% trans 'Internal' %}"><span class="glyphicon glyphicon-lock" aria-hidden="true"></span></span>
+							{% elif minute.state == minute.PUBLISHED %}
+								<span class="text-gray" data-toggle="tooltip" data-placement="top" data-container="body" title="{% trans 'Published for Students and University Network' %}"><span class="glyphicon glyphicon-education" aria-hidden="true"></span><span class="glyphicon glyphicon-user" aria-hidden="true"></span></span>
+							{% elif minute.state == minute.PUBLISHED_STUDENT %}
+								<span class="text-gray" data-toggle="tooltip" data-placement="top" data-container="body" title="{% trans 'Published for Students' %}"><span class="glyphicon glyphicon-user" aria-hidden="true"></span></span>
+							{% elif minute.state == minute.CUSTOM %}
+								<span class="text-gray" data-toggle="tooltip" data-placement="top" data-container="body" title="{% trans 'Custom Permissions' %}"><span class="glyphicon glyphicon-cog" aria-hidden="true"></span></span>
+							{% endif %}
+						</td>
+					{% endif %}
+					<td class="col-xs-2">
 						{% for label in minute.labels.all %}
 							<span class="label {{ label.class_for_text_color }}" style="background-color: {{ label.color }};">{{ label.title }}</span>
 						{% endfor %}
-						{% if minute.state == minute.UNPUBLISHED %}
-							<span class="label label-danger">{% trans "Unpublished" %}</span>
-						{% elif minute.state == minute.INTERNAL %}
-							<span class="label label-warning">{% trans "Internal" %}</span>
-						{% endif %}
 					</td>
 					<td class="col-xs-7">
 						<a href="{{ minute.get_view_url }}">{{ minute.title }}</a>

--- a/_1327/minutes/tests.py
+++ b/_1327/minutes/tests.py
@@ -166,6 +166,47 @@ class TestEditor(WebTest):
 		self.assertTrue(checker.has_perm(document.delete_permission_name, document))
 
 
+class TestMinutesList(WebTest):
+	csrf_checks = False
+
+	def setUp(self):
+		self.user = mommy.make(UserProfile, is_superuser=True)
+		self.minutes_document = mommy.make(MinutesDocument)
+		self.group = mommy.make(Group)
+		self.minutes_document.set_all_permissions(self.group)
+
+	def test_list_permission_display(self):
+		"""
+		Test if the permissions are correctly shown in the minutes list
+		"""
+		self.assertEqual(MinutesDocument.objects.count(), 1)
+
+		self.minutes_document.state = MinutesDocument.UNPUBLISHED
+		self.minutes_document.save()
+		response = self.app.get(reverse("minutes:list", args=[self.group.id]), user=self.user)
+		self.assertIn("glyphicon-alert", response)
+
+		self.minutes_document.state = MinutesDocument.PUBLISHED
+		self.minutes_document.save()
+		response = self.app.get(reverse("minutes:list", args=[self.group.id]), user=self.user)
+		self.assertIn("glyphicon-education", response)
+
+		self.minutes_document.state = MinutesDocument.INTERNAL
+		self.minutes_document.save()
+		response = self.app.get(reverse("minutes:list", args=[self.group.id]), user=self.user)
+		self.assertIn("glyphicon-lock", response)
+
+		self.minutes_document.state = MinutesDocument.CUSTOM
+		self.minutes_document.save()
+		response = self.app.get(reverse("minutes:list", args=[self.group.id]), user=self.user)
+		self.assertIn("glyphicon-cog", response)
+
+		self.minutes_document.state = MinutesDocument.PUBLISHED_STUDENT
+		self.minutes_document.save()
+		response = self.app.get(reverse("minutes:list", args=[self.group.id]), user=self.user)
+		self.assertIn("glyphicon-user", response)
+
+
 class TestNewMinutesDocument(WebTest):
 	csrf_checks = False
 

--- a/_1327/minutes/views.py
+++ b/_1327/minutes/views.py
@@ -14,6 +14,7 @@ def list(request, groupid):
 		raise Http404
 	result = {}
 
+	own_group = group in request.user.groups.all()
 	minutes = MinutesDocument.objects.all().prefetch_related('labels').order_by('-date')
 	# Prefetch group permissions
 	group_checker = ObjectPermissionChecker(group)
@@ -42,4 +43,5 @@ def list(request, groupid):
 		result[m.date.year].append(m)
 	return render(request, "minutes_list.html", {
 		'minutes_list': sorted(result.items(), reverse=True),
+		'own_group': own_group
 	})

--- a/_1327/minutes/views.py
+++ b/_1327/minutes/views.py
@@ -14,7 +14,7 @@ def list(request, groupid):
 		raise Http404
 	result = {}
 
-	own_group = group in request.user.groups.all()
+	own_group = request.user.is_superuser or group in request.user.groups.all()
 	minutes = MinutesDocument.objects.all().prefetch_related('labels').order_by('-date')
 	# Prefetch group permissions
 	group_checker = ObjectPermissionChecker(group)

--- a/_1327/polls/views.py
+++ b/_1327/polls/views.py
@@ -13,7 +13,7 @@ from markdown.extensions.toc import TocExtension
 
 from _1327.documents.markdown_internal_link_extension import InternalLinksMarkdownExtension
 from _1327.documents.models import Document
-from _1327.main.utils import abbreviation_explanation_markdown, get_permission_overview
+from _1327.main.utils import abbreviation_explanation_markdown, document_permission_overview
 from _1327.polls.models import Poll
 from _1327.user_management.shortcuts import check_permissions
 
@@ -65,11 +65,6 @@ def results(request, poll, url_title):
 	md = markdown.Markdown(safe_mode='escape', extensions=[TocExtension(baselevel=2), InternalLinksMarkdownExtension(), 'markdown.extensions.abbr', 'markdown.extensions.tables'])
 	description = md.convert(poll.text + abbreviation_explanation_markdown())
 
-	can_edit = request.user.has_perm(poll.edit_permission_name, poll)
-	permission_overview = []
-	if can_edit:
-		permission_overview = get_permission_overview(poll)
-
 	return render(
 		request,
 		'polls_results.html',
@@ -80,8 +75,7 @@ def results(request, poll, url_title):
 			'active_page': 'view',
 			'view_page': True,
 			'attachments': poll.attachments.filter(no_direct_download=False).order_by('index'),
-			'can_edit': can_edit,
-			'permission_overview': permission_overview,
+			'permission_overview': document_permission_overview(request.user, poll),
 		}
 	)
 
@@ -117,11 +111,6 @@ def vote(request, poll, url_title):
 	md = markdown.Markdown(safe_mode='escape', extensions=[TocExtension(baselevel=2), InternalLinksMarkdownExtension(), 'markdown.extensions.abbr', 'markdown.extensions.tables'])
 	description = md.convert(poll.text + abbreviation_explanation_markdown())
 
-	can_edit = request.user.has_perm(poll.edit_permission_name, poll)
-	permission_overview = []
-	if can_edit:
-		permission_overview = get_permission_overview(poll)
-
 	return render(
 		request,
 		'polls_vote.html',
@@ -133,8 +122,7 @@ def vote(request, poll, url_title):
 			'view_page': True,
 			"widget": "checkbox" if poll.max_allowed_number_of_answers != 1 else "radio",
 			'attachments': poll.attachments.filter(no_direct_download=False).order_by('index'),
-			'can_edit': can_edit,
-			'permission_overview': permission_overview,
+			'permission_overview': document_permission_overview(request.user, poll),
 		}
 	)
 

--- a/_1327/polls/views.py
+++ b/_1327/polls/views.py
@@ -13,8 +13,7 @@ from markdown.extensions.toc import TocExtension
 
 from _1327.documents.markdown_internal_link_extension import InternalLinksMarkdownExtension
 from _1327.documents.models import Document
-from _1327.documents.utils import permission_warning
-from _1327.main.utils import abbreviation_explanation_markdown
+from _1327.main.utils import abbreviation_explanation_markdown, get_permission_overview
 from _1327.polls.models import Poll
 from _1327.user_management.shortcuts import check_permissions
 
@@ -66,6 +65,11 @@ def results(request, poll, url_title):
 	md = markdown.Markdown(safe_mode='escape', extensions=[TocExtension(baselevel=2), InternalLinksMarkdownExtension(), 'markdown.extensions.abbr', 'markdown.extensions.tables'])
 	description = md.convert(poll.text + abbreviation_explanation_markdown())
 
+	can_edit = request.user.has_perm(poll.edit_permission_name, poll)
+	permission_overview = []
+	if can_edit:
+		permission_overview = get_permission_overview(poll)
+
 	return render(
 		request,
 		'polls_results.html',
@@ -76,7 +80,8 @@ def results(request, poll, url_title):
 			'active_page': 'view',
 			'view_page': True,
 			'attachments': poll.attachments.filter(no_direct_download=False).order_by('index'),
-			'permission_warning': permission_warning(request.user, poll),
+			'can_edit': can_edit,
+			'permission_overview': permission_overview,
 		}
 	)
 
@@ -112,6 +117,11 @@ def vote(request, poll, url_title):
 	md = markdown.Markdown(safe_mode='escape', extensions=[TocExtension(baselevel=2), InternalLinksMarkdownExtension(), 'markdown.extensions.abbr', 'markdown.extensions.tables'])
 	description = md.convert(poll.text + abbreviation_explanation_markdown())
 
+	can_edit = request.user.has_perm(poll.edit_permission_name, poll)
+	permission_overview = []
+	if can_edit:
+		permission_overview = get_permission_overview(poll)
+
 	return render(
 		request,
 		'polls_vote.html',
@@ -123,7 +133,8 @@ def vote(request, poll, url_title):
 			'view_page': True,
 			"widget": "checkbox" if poll.max_allowed_number_of_answers != 1 else "radio",
 			'attachments': poll.attachments.filter(no_direct_download=False).order_by('index'),
-			'permission_warning': permission_warning(request.user, poll),
+			'can_edit': can_edit,
+			'permission_overview': permission_overview,
 		}
 	)
 

--- a/_1327/static/less/1327.less
+++ b/_1327/static/less/1327.less
@@ -90,6 +90,22 @@ h6 {
 	font-size: 15px;
 }
 
+.text-red {
+	color: @hpi-red;
+}
+.text-orange {
+	color: @hpi-orange;
+}
+.text-yellow {
+	color: @hpi-yellow;
+}
+.text-gray {
+	color: @hpi-gray;
+}
+.text-blue {
+	color: @hpi-blue;
+}
+
 a {
 	cursor: pointer;
 }

--- a/_1327/static/less/1327.less
+++ b/_1327/static/less/1327.less
@@ -105,6 +105,26 @@ h6 {
 .text-blue {
 	color: @hpi-blue;
 }
+.text-green {
+	color: @green;
+}
+
+.permission-icons {
+	text-align: center;
+}
+.permission-icon-more {
+	.text-gray;
+	padding-left: 10px;
+}
+.permission-icon-edit {
+	.text-blue;
+}
+.permission-icon-view {
+	.text-green;
+}
+.permission-icon-none {
+	.text-red;
+}
 
 a {
 	cursor: pointer;


### PR DESCRIPTION
This adds an overview about permissions at two places:

**Minutes list**
![minutes_publishinfo](https://cloud.githubusercontent.com/assets/1781719/23181593/d4a594ea-f875-11e6-92e8-f6cef6ca447f.PNG)
On the minutes list an additional column is added, showing whether minutes documents are unpublished, internal, published for students, or published for students and university network (or custom). This replaces the labels "Unpublished" and "Internal".

**Document sidebar**
![permissioninfo](https://cloud.githubusercontent.com/assets/1781719/23181744/6c8f10ce-f876-11e6-89a2-406f33d3c546.PNG)
In the sidebar of documents the permissions button was moved to the bottom and users who can edit the page will see four icons (Anonymous, University Network, Student, Staff) in different colors (blue: can edit, green: can view, red: can't view). If other groups than these four main groups have view or edit permissions, an additional icon with three dots is shown. A tooltip shows a complete list when hovering over the icons.