### PR TITLE
Reminder for unpublished minutes

### DIFF
--- a/_1327/main/management/commands/send_reminders.py
+++ b/_1327/main/management/commands/send_reminders.py
@@ -1,0 +1,35 @@
+import datetime
+import logging
+
+from django.conf import settings
+from django.core.mail import EmailMessage
+from django.core.management.base import BaseCommand
+from django.utils.translation import ugettext_lazy as _
+
+from _1327.minutes.models import MinutesDocument
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+	args = ''
+	help = 'Send reminders for unpublished minutes'
+
+	def handle(self, *args, **options):
+		check_date = datetime.date.today() - datetime.timedelta(days=settings.MINUTES_PUBLISH_REMINDER_DAYS)
+		due_unpublished_minutes_documents = MinutesDocument.objects.filter(state=MinutesDocument.UNPUBLISHED, date=check_date)
+		for minutes_document in due_unpublished_minutes_documents:
+			mail = EmailMessage(
+				subject=_("Minutes publish reminder"),
+				body=_('Please remember to publish the minutes document "{}" from {} ({}).'.format(
+					minutes_document.title,
+					minutes_document.date.strftime("%d.%m.%Y"),
+					settings.PAGE_URL + minutes_document.get_view_url()
+				)),
+				to=[minutes_document.author.email],
+				bcc=[a[1] for a in settings.ADMINS]
+			)
+			try:
+				mail.send(False)
+			except Exception:
+				logger.exception('An exception occurred when sending the following email to user "{}":\n{}\n'.format(minutes_document.author.username, mail.message()))

--- a/_1327/settings.py
+++ b/_1327/settings.py
@@ -27,6 +27,16 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
+# The page URL that is used in email templates
+PAGE_URL = "localhost:8000"
+
+
+# People who receive emails on errors
+ADMINS = [
+	# ('Your Name', 'your_email@example.com'),
+]
+
+
 DELETE_EMPTY_PAGE_AFTER = timedelta(hours=1)
 
 FORBIDDEN_URLS = [
@@ -57,6 +67,9 @@ ANONYMOUS_IP_RANGE_GROUPS = {
 
 MINUTES_URL_NAME = "minutes"
 POLLS_URL_NAME = "polls"
+
+# number of days after which a reminder for unpublished minutes documents is sent
+MINUTES_PUBLISH_REMINDER_DAYS = 6
 
 
 # Application definition
@@ -144,6 +157,13 @@ CHANNEL_LAYERS = {
 	},
 }
 PREVIEW_URL = '/ws/preview'
+
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+EMAIL_HOST = ''
+EMAIL_PORT = '25'
+DEFAULT_FROM_EMAIL = 'noreply@example.com'
+SERVER_EMAIL = 'noreply@example.com'
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.6/topics/i18n/


### PR DESCRIPTION
fix #119 
this adds a management command that sends reminders for unpublished minutes documents. it should be called from a daily cronjob.