### PR TITLE
Fix #622; show last editor of information document

### DIFF
--- a/_1327/documents/models.py
+++ b/_1327/documents/models.py
@@ -159,6 +159,13 @@ class Document(PolymorphicModel):
 		return last_revision.revision.date_created
 
 	@property
+	def last_author(self):
+		last_revision = Version.objects.get_for_object(self).order_by('revision__date_created').last()
+		if last_revision is None:
+			return None
+		return last_revision.revision.user
+
+	@property
 	def is_in_creation(self):
 		return not self.has_perms()
 

--- a/_1327/information_pages/templates/information_pages_meta_information.html
+++ b/_1327/information_pages/templates/information_pages_meta_information.html
@@ -1,15 +1,14 @@
 {% load i18n %}
 
 <dl class="meta-information">
-	{% comment %}
-		Don't show authors for now. Could be changed in #425
-		<dt>{% blocktrans count counter=document.authors|length %}Author{% plural %}Authors{% endblocktrans %}</dt>
-		<dd>{% for author in document.authors %}{{ author }}{% if not forloop.last %}, {% endif %}{% endfor %}</dd>
-	{% endcomment %}
 	{% if permission_overview %}
 		<dt>{% trans "Created" %}</dt>
 		<dd>{{ document.created|date:"d.m.Y, H:i" }}</dd>
 	{% endif %}
 	<dt>{% trans "Last change" %}</dt>
-	<dd>{{ document.last_change|date:"d.m.Y, H:i" }}</dd>
+	<dd>{{ document.last_change|date:"d.m.Y, H:i" }}
+		{% if document.last_author %}
+			<i>{% trans "by" %}</i> {{ document.last_author }}
+		{% endif %}
+	</dd>
 </dl>

--- a/_1327/information_pages/tests.py
+++ b/_1327/information_pages/tests.py
@@ -203,6 +203,10 @@ class TestVersions(WebTest):
 		self.assertEqual(versions[1].revision.comment, 'test version')
 
 	def test_last_author(self):
+		# test whether last author is part of page
+		response = self.app.get(self.document.get_view_url(), user=self.user)
+		self.assertIn('<i>by</i> {}'.format(self.user.username), response.body.decode('utf-8'))
+
 		# create a second user
 		user2 = mommy.make(UserProfile, is_superuser=True)
 		user2.groups.add(self.group)

--- a/_1327/information_pages/tests.py
+++ b/_1327/information_pages/tests.py
@@ -150,6 +150,7 @@ class TestEditor(WebTest):
 
 class TestVersions(WebTest):
 	csrf_checks = False
+	extra_environ = {'HTTP_ACCEPT_LANGUAGE': 'en'}
 
 	@classmethod
 	def setUpTestData(cls):
@@ -200,6 +201,22 @@ class TestVersions(WebTest):
 		# check whether the comment of the version correct
 		self.assertEqual(versions[0].revision.comment, 'hallo Bibi Blocksberg')
 		self.assertEqual(versions[1].revision.comment, 'test version')
+
+	def test_last_author(self):
+		# create a second user
+		user2 = mommy.make(UserProfile, is_superuser=True)
+		user2.groups.add(self.group)
+
+		# create second revision
+		self.document.text = 'christi was here'
+		with transaction.atomic(), revisions.create_revision():
+			self.document.save()
+			revisions.set_user(user2)
+			revisions.set_comment('test version 2')
+
+		# test whether last author is part of page
+		response = self.app.get(self.document.get_view_url(), user=self.user)
+		self.assertIn('<i>by</i> {}'.format(user2.username), response.body.decode('utf-8'))
 
 
 class TestPermissions(WebTest):


### PR DESCRIPTION
This fix is a fix which fixes #622: Show last editor of information document.