### PR TITLE
 Add image scaling option in document editor's "add image" modal

### DIFF
--- a/_1327/documents/templates/documents_edit.html
+++ b/_1327/documents/templates/documents_edit.html
@@ -37,7 +37,10 @@
 	<h2>{% trans "Preview" %} <a id="shareText" class="hidden">Share</a></h2>
 	<div class="divider"></div>
 	<div id="text-preview"></div>
+{% endblock %}
 
+{% block modals %}
+{{ block.super }}
 	<div class="modal fade ontop" id="selectImageAttachment" tabindex="-1" role="dialog" aria-hidden="true">
 		<div class="modal-dialog">
 			<div class="modal-content">

--- a/_1327/documents/templates/documents_edit.html
+++ b/_1327/documents/templates/documents_edit.html
@@ -14,7 +14,7 @@
 
 	{% for new_autosaved_page in new_autosaved_pages %}
 		<div class="alert alert-danger alert-margin-bottom" role="alert">{% blocktrans with date=new_autosaved_page.created %}There is an autosaved text (saved on {{ date }}){% endblocktrans %}, {% trans "you can restore this unsaved text:" %} <a href="{{ new_autosaved_page.document.get_edit_url }}?restore={{ new_autosaved_page.id }}" class="btn-sm btn-default">{% trans "Restore" %}</a></div>
-	{%  endfor %}
+	{% endfor %}
 
 <form action="{{ document.get_edit_url }}" method="post" class="form-horizontal" role="form" id="document-form">
 	{% bootstrap_form form layout='horizontal' %}
@@ -57,10 +57,10 @@
 					<select class="form-control" id="attachmentModalSelect"></select>
 					<div class="editor-image-modal-scale-container pt-2">
 						<span class="editor-image-modal-scale-label pr-1">{% trans "Scale:" %}</span>
-					  <input type="text" class="form-control editor-image-modal-scale-input" id="attachmentWidthInput" placeholder="{% trans "Width (optional)" %}" />
+						<input type="text" class="form-control editor-image-modal-scale-input" id="attachmentWidthInput" placeholder="{% trans "Width (optional)" %}" />
 						<span class="editor-image-modal-scale-label px-1">and/or</span>
-					  <input type="text" class="form-control editor-image-modal-scale-input" id="attachmentHeightInput" placeholder="{% trans "Height (optional)" %}" />
-				  </div>
+						<input type="text" class="form-control editor-image-modal-scale-input" id="attachmentHeightInput" placeholder="{% trans "Height (optional)" %}" />
+					</div>
 					<div class="divider"></div>
 					<h2>{% trans "Preview" %}</h2>
 					<div class="preview">
@@ -142,7 +142,7 @@
 				<div class="modal-title">{% trans "Autosave failed" %}</div>
 			</div>
 			<div class="modal-body">
-                <span class="autosaveErrorDialogExplanation"></span>
+				<span class="autosaveErrorDialogExplanation"></span>
 			</div>
 			<div class="modal-footer">
 				<button type="button" class="btn btn-primary autosaveErrorDialogClose">{% trans "Close" %}</button>
@@ -414,28 +414,28 @@
 					destinationElement.removeClass('hidden');
 				},
 				error: function(jqXHR, textStatus, errorThrown) {
-                    var reasonDisplay = $('.autosaveErrorDialogExplanation');
-                    var statusCode = jqXHR.status;
-                    var reason = "";
-                    switch (statusCode) {
-                        case 403:
-                            reason = "{% trans "Probably you are logged out!" %}";
-                            break;
-                        case 404:
-                            reason = "{% trans "The document you are editing does not exist!" %}";
-                            break;
-                        default:
-                            reason = "{% trans "There was an unknown error!" %}";
-                            break;
-                    }
-                    reasonDisplay.html(reason);
+					var reasonDisplay = $('.autosaveErrorDialogExplanation');
+					var statusCode = jqXHR.status;
+					var reason = "";
+					switch (statusCode) {
+						case 403:
+							reason = "{% trans "Probably you are logged out!" %}";
+							break;
+						case 404:
+							reason = "{% trans "The document you are editing does not exist!" %}";
+							break;
+						default:
+							reason = "{% trans "There was an unknown error!" %}";
+							break;
+					}
+					reasonDisplay.html(reason);
 
-                    var errorDisplay = $('#autosaveErrorDialog');
-                    errorDisplay.modal();
-                    $('.autosaveErrorDialogClose').on('click', function() {
-                        errorDisplay.modal('hide');
-                    });
-                }
+					var errorDisplay = $('#autosaveErrorDialog');
+					errorDisplay.modal();
+					$('.autosaveErrorDialogClose').on('click', function() {
+						errorDisplay.modal('hide');
+					});
+				}
 			});
 		}
 		setTimeout(function() { save(); }, 10000);
@@ -443,10 +443,10 @@
 	save();
 
 	// Activate Select2 if present on page
-    $(".select2-selection").select2({
-        language: "{{ LANGUAGE_CODE }}",
-        placeholder: "{% trans 'Please select...' %}"
-    });
+	$(".select2-selection").select2({
+		language: "{{ LANGUAGE_CODE }}",
+		placeholder: "{% trans 'Please select...' %}"
+	});
 
 	$(".select2-selection-clearable").select2({
 		language: "{{ LANGUAGE_CODE }}",

--- a/_1327/documents/templates/documents_edit.html
+++ b/_1327/documents/templates/documents_edit.html
@@ -57,9 +57,9 @@
 					<select class="form-control" id="attachmentModalSelect"></select>
 					<div class="editor-image-modal-scale-container pt-2">
 						<span class="editor-image-modal-scale-label pr-1">{% trans "Scale:" %}</span>
-						<input type="text" class="form-control editor-image-modal-scale-input" id="attachmentWidthInput" placeholder="{% trans "Width (optional)" %}" />
+						<input type="number" class="form-control editor-image-modal-scale-input" id="attachmentWidthInput" placeholder="{% trans "Width (optional)" %}" />
 						<span class="editor-image-modal-scale-label px-1">and/or</span>
-						<input type="text" class="form-control editor-image-modal-scale-input" id="attachmentHeightInput" placeholder="{% trans "Height (optional)" %}" />
+						<input type="number" class="form-control editor-image-modal-scale-input" id="attachmentHeightInput" placeholder="{% trans "Height (optional)" %}" />
 					</div>
 					<div class="divider"></div>
 					<h2>{% trans "Preview" %}</h2>

--- a/_1327/documents/templates/documents_edit.html
+++ b/_1327/documents/templates/documents_edit.html
@@ -55,6 +55,12 @@
 						{% trans "Error! Could not upload image." %}
 					</div>
 					<select class="form-control" id="attachmentModalSelect"></select>
+					<div class="editor-image-modal-scale-container pt-2">
+						<span class="editor-image-modal-scale-label pr-1">{% trans "Scale:" %}</span>
+					  <input type="text" class="form-control editor-image-modal-scale-input" id="attachmentWidthInput" placeholder="{% trans "Width (optional)" %}" />
+						<span class="editor-image-modal-scale-label px-1">and/or</span>
+					  <input type="text" class="form-control editor-image-modal-scale-input" id="attachmentHeightInput" placeholder="{% trans "Height (optional)" %}" />
+				  </div>
 					<div class="divider"></div>
 					<h2>{% trans "Preview" %}</h2>
 					<div class="preview">
@@ -164,8 +170,9 @@
 		});
 	}, 1000);
 
-	function addImageToText(editor, attachmentHash, modal) {
-		var chunk = "![Image Alt]({% url 'documents:download_attachment' %}?hash_value=" + attachmentHash + "&embed=True)";
+	function addImageToText(editor, attachmentHash, attachmentWidth, attachmentHeight, modal) {
+		var scaleText = (attachmentWidth || attachmentHeight) ? (" =" + attachmentWidth + "x" + attachmentHeight) : "";
+		var chunk = "![Image Alt]({% url 'documents:download_attachment' %}?hash_value=" + attachmentHash + "&embed=True" + scaleText + ")";
 		editor.replaceSelection(chunk);
 		var cursor = editor.getSelection();
 
@@ -235,8 +242,9 @@
 							}
 							// find the right spot to insert the text and create the correct markdown
 							var attachmentHash = select.val();
-							addImageToText(e, attachmentHash, modalItem)
-
+							var attachmentWidth = $('#attachmentWidthInput').val();
+							var attachmentHeight = $('#attachmentHeightInput').val();
+							addImageToText(e, attachmentHash, attachmentWidth, attachmentHeight, modalItem);
 						});
 
 						// enable image uploading
@@ -263,6 +271,9 @@
 							var formData = new FormData(this);
 							formData.append("document", {{ document.id }});
 
+							var attachmentWidth = $('#attachmentWidthInput').val();
+							var attachmentHeight = $('#attachmentHeightInput').val();
+
 							$.ajax({
 								url: "{% url 'documents:create_attachment' %}",
 								data: formData,
@@ -270,7 +281,7 @@
 								contentType: false,
 								type: 'POST',
 								success: function (data) {
-									addImageToText(e, data, modalItem);
+									addImageToText(e, data, attachmentWidth, attachmentHeight, modalItem);
 								},
 								error: function () {
 									$('#image-upload-error-display').removeClass('hidden');

--- a/_1327/information_pages/tests.py
+++ b/_1327/information_pages/tests.py
@@ -78,7 +78,7 @@ class TestEditor(WebTest):
 		response = self.app.get(reverse(self.document.get_edit_url_name(), args=[self.document.url_title]), user=self.user)
 		self.assertEqual(response.status_code, 200)
 
-		form = response.forms[0]
+		form = response.forms['document-form']
 		self.assertEqual(form.get('title').value, self.document.title)
 		self.assertEqual(form.get('text').value, self.document.text)
 
@@ -97,7 +97,7 @@ class TestEditor(WebTest):
 		for string in ['', ' ']:
 			response = self.app.get(reverse(self.document.get_edit_url_name(), args=[self.document.url_title]), user=self.user)
 
-			form = response.forms[0]
+			form = response.forms['document-form']
 			form.set('title', string)
 			response = form.submit()
 			self.assertEqual(response.status_code, 200)
@@ -106,7 +106,7 @@ class TestEditor(WebTest):
 	def test_editor_slug_error(self):
 		response = self.app.get(reverse(self.document.get_edit_url_name(), args=[self.document.url_title]), user=self.user)
 
-		form = response.forms[0]
+		form = response.forms['document-form']
 		form.set('url_title', 'not_ALLOWED!')
 		response = form.submit()
 		self.assertEqual(response.status_code, 200)
@@ -186,7 +186,7 @@ class TestVersions(WebTest):
 		response = self.app.get(reverse(self.document.get_edit_url_name(), args=[self.document.url_title]), user=self.user)
 		self.assertEqual(response.status_code, 200)
 
-		form = response.forms[0]
+		form = response.forms['document-form']
 		new_string = self.document.text + "\nHallo Bibi Blocksberg!!"
 		form.set('text', new_string)
 		form.set('comment', 'hallo Bibi Blocksberg')
@@ -359,7 +359,7 @@ class TestNewPage(WebTest):
 		response = self.app.get(reverse('documents:create', args=['informationdocument']), user=self.user)
 		self.assertEqual(response.status_code, 200)
 
-		form = response.forms[0]
+		form = response.forms['document-form']
 		text = "Hallo Bibi Blocksberg!"
 		form.set('text', text)
 		form.set('title', text)
@@ -386,7 +386,7 @@ class TestNewPage(WebTest):
 		response = self.app.get(reverse('documents:create', args=['informationdocument']), user=self.user)
 		self.assertEqual(response.status_code, 200)
 
-		form = response.forms[0]
+		form = response.forms['document-form']
 		text = "Lorem ipsum"
 		url = "some/page-with-slash"
 		form.set('text', text)
@@ -419,7 +419,7 @@ class TestNewPage(WebTest):
 		response = self.app.get(reverse('documents:create', args=['informationdocument']), user=self.user)
 		self.assertEqual(response.status_code, 200)
 
-		form = response.forms[0]
+		form = response.forms['document-form']
 		self.assertTrue("Hidden" in str(form.fields['group'][0]))
 
 	def test_group_field_not_hidden_when_user_has_multiple_groups(self):
@@ -429,7 +429,7 @@ class TestNewPage(WebTest):
 		response = self.app.get(reverse('documents:create', args=['informationdocument']), user=self.user)
 		self.assertEqual(response.status_code, 200)
 
-		form = response.forms[0]
+		form = response.forms['document-form']
 		self.assertFalse("Hidden" in str(form.fields['group'][0]))
 
 

--- a/_1327/minutes/tests.py
+++ b/_1327/minutes/tests.py
@@ -48,7 +48,7 @@ class TestEditor(WebTest):
 		response = self.app.get(reverse(self.document.get_edit_url_name(), args=[self.document.url_title]), user=self.user)
 		self.assertEqual(response.status_code, 200)
 
-		form = response.forms[0]
+		form = response.forms['document-form']
 		self.assertEqual(form.get('title').value, self.document.title)
 		self.assertEqual(form.get('text').value, self.document.text)
 		self.assertEqual(int(form.get('moderator').value), self.document.moderator.id)
@@ -260,7 +260,7 @@ class TestNewMinutesDocument(WebTest):
 		response = self.app.get(reverse('documents:create', args=['minutesdocument']) + '?group={}'.format(self.group.id), user=self.user)
 		self.assertEqual(response.status_code, 200)
 
-		form = response.forms[0]
+		form = response.forms['document-form']
 		text = "Lorem ipsum"
 		form.set('text', text)
 		form.set('comment', text)
@@ -296,7 +296,7 @@ class TestNewMinutesDocument(WebTest):
 		response = self.app.get(reverse('documents:create', args=['minutesdocument']) + '?group={}'.format(self.group.id), user=self.user)
 		self.assertEqual(response.status_code, 200)
 
-		form = response.forms[0]
+		form = response.forms['document-form']
 		text = "Lorem ipsum"
 		form.set('text', text)
 		form.set('comment', text)
@@ -318,7 +318,7 @@ class TestNewMinutesDocument(WebTest):
 		response = self.app.get(reverse('documents:create', args=['minutesdocument']) + '?group={}'.format(self.group.id), user=self.user)
 		self.assertEqual(response.status_code, 200)
 
-		form = response.forms[0]
+		form = response.forms['document-form']
 		self.assertTrue("Hidden" in str(form.fields['group'][0]))
 
 	def test_group_field_not_hidden_when_user_has_multiple_groups(self):
@@ -328,7 +328,7 @@ class TestNewMinutesDocument(WebTest):
 		response = self.app.get(reverse('documents:create', args=['minutesdocument']) + '?group={}'.format(self.group.id), user=self.user)
 		self.assertEqual(response.status_code, 200)
 
-		form = response.forms[0]
+		form = response.forms['document-form']
 		self.assertFalse("Hidden" in str(form.fields['group'][0]))
 
 

--- a/_1327/static/less/1327.less
+++ b/_1327/static/less/1327.less
@@ -4,6 +4,20 @@
 @import "../bootstrap/less/mixins.less";
 @import "../bootstrap-markdown/less/bootstrap-markdown.less";
 
+// Add future Bootstrap 4 classes which are missing in Bootstrap 3
+// TODO: Remove these after update to Bootstrap 4
+.pt-2 {
+	padding-top: 2rem;
+}
+.px-1 {
+	padding-left: 1rem;
+	padding-right: 1rem;
+}
+.pr-1 {
+	padding-right: 1rem;
+}
+// End missing classes
+
 // Fix bootstrap:
 .modal-dialog {
 	z-index: @zindex-modal-background + 1;
@@ -604,6 +618,18 @@ div.radio {
 }
 #document-form #id_state {
 	padding-top: (@padding-base-vertical + 1);
+}
+
+.editor-image-modal-scale-container {
+	display: flex;
+}
+.editor-image-modal-scale-input {
+	flex: 1;
+}
+.editor-image-modal-scale-label {
+	white-space: nowrap;
+	margin-top: auto;
+	margin-bottom: auto;
 }
 
 .toc ul {

--- a/_1327/templates/master.html
+++ b/_1327/templates/master.html
@@ -27,8 +27,10 @@
 	{% endblock %}
 </head>
 <body>
+{% block modals %}
+{% endblock %}
 {% block body %}
-{% endblock body %}
+{% endblock %}
 <!-- Script that automatically adds the csrf cookie for ajax post requests -->
 <script type="text/javascript" src="{% static 'js/utils.js' %}"></script>
 {% block scripts %}


### PR DESCRIPTION
Closes #632 by adding image scaling inputs to the "add image" modal of the document editor.