### PR TITLE
Fix overflowing text in content section by forcing word wraps

### DIFF
--- a/_1327/static/less/1327.less
+++ b/_1327/static/less/1327.less
@@ -355,9 +355,10 @@ nav li:hover > .dropdown-menu {
 	padding-left: 20px;
 	margin-bottom: 30px;
 	// Wraps all overflowing text in the content section, regardless whether it's part
-	// of the main text, of the attachments list or table or any other content element
-	word-wrap: break-word;
-	word-break: break-all;
+	// of the main text or any other content element.
+	// Note that this doesn't work for the attachments table.
+	// See the attachments table CSS below (#attachment-table) for details.
+	overflow-wrap: break-word;
 }
 
 .content :first-child {
@@ -596,6 +597,18 @@ table.table-narrow {
 }
 table.vertically-aligned tr td {
 	vertical-align: middle;
+}
+
+table#attachment-table td {
+	// The global content word wrapping doesn't work for tables since
+	// "overflow-wrap: break-word" doesn't wrap in flexible containers like table
+	// columns. Adding "table-layout: fixed" would fix that, but screws up the
+	// attachments table's layout. Thus, we resort to this CSS property which works
+	// with flexible containers, but doesn't wrap words as nicely as "break-word".
+	// Note that a "word-break: break-word" property could solve this whole
+	// situation, but isn't yet supported in any browser and probably won't be
+	// for some time.
+	word-break: break-all;
 }
 
 div.radio {

--- a/_1327/static/less/1327.less
+++ b/_1327/static/less/1327.less
@@ -354,6 +354,10 @@ nav li:hover > .dropdown-menu {
 .container.content {
 	padding-left: 20px;
 	margin-bottom: 30px;
+	// Wraps all overflowing text in the content section, regardless whether it's part
+	// of the main text, of the attachments list or table or any other content element
+	word-wrap: break-word;
+	word-break: break-all;
 }
 
 .content :first-child {
@@ -592,10 +596,6 @@ table.table-narrow {
 }
 table.vertically-aligned tr td {
 	vertical-align: middle;
-}
-
-table#attachment-table td {
-	word-break: break-all;
 }
 
 div.radio {


### PR DESCRIPTION
Fixes #634.

Note: This PR doesn't remove the diff table word wrap fix introduced in #106 since that fix applies to diff tables in general, not just diff tables in content. In case a diff table is used outside of the content div in the future, that fix should still work. Thus, it's not removed and covered by the new general content word wrap policy.