### PR TITLE
Rename `virtualenv` to `env` because it's shorter to type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/virtualenv/
+/env/
 .vagrant
 
 # Byte-compiled / optimized / DLL files


### PR DESCRIPTION
This change only affects the .gitignore since the README already calls virtualenvs `env`.