### PR TITLE
Add meta tags recommended by Bootstrap to enable mobile layout

### DIFF
--- a/_1327/templates/master.html
+++ b/_1327/templates/master.html
@@ -7,6 +7,9 @@
 <html>
 <head>
 	{% block header %}
+		<meta charset="utf-8">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<title>myHPI – {% block title %}{% endblock %}</title>
 		<link rel="stylesheet" href="{% static 'less/bootstrap.less'|compile %}" />
 		<link rel="stylesheet" href="{% static 'font-awesome/less/font-awesome.less'|compile %}" />


### PR DESCRIPTION
| before | after |
| ------ | ----- |
| ![grafik](https://user-images.githubusercontent.com/2145092/48585858-47f7f500-e92e-11e8-9597-ebd1f7e05809.png) | ![grafik](https://user-images.githubusercontent.com/2145092/48585867-4d553f80-e92e-11e8-91ee-467bb2018b02.png) |

Please note that this can **not** be tested in a desktop browser. The meta tags were taken from here: https://getbootstrap.com/docs/3.3/getting-started/#template