### PR TITLE
Drop Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
-sudo: false
 python:
-  - "3.4"
+  - "3.6"
+  - "3.7"
+dist: xenial
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.12.3
   - export PATH=$HOME/.yarn/bin:$PATH


### PR DESCRIPTION
This is @Bartzi's commit, cherry-picked from https://github.com/fsr-itse/1327/pull/667. I've removed the `sudo` key completely, because it [won't be supported much longer](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).
My email RFC uses features of Python 3.6 and I'd like to see the tests run through on Travis.